### PR TITLE
Raise Error when DBAddress is unset

### DIFF
--- a/api/v1beta1/client.go
+++ b/api/v1beta1/client.go
@@ -64,7 +64,11 @@ func GetDBEndpoints(
 	}
 	DBEndpointsMap := make(map[string]string)
 	for _, ovndb := range ovnDBList.Items {
-		DBEndpointsMap[ovndb.Spec.DBType] = ovndb.Status.DBAddress
+		if  ovndb.Status.DBAddress != "" {
+			DBEndpointsMap[ovndb.Spec.DBType] = ovndb.Status.DBAddress
+		} else {
+			return DBEndpointsMap, fmt.Errorf("DBEndpoint not ready yet for %s", ovndb.Spec.DBType)
+		}
 	}
 	return DBEndpointsMap, nil
 }


### PR DESCRIPTION
OVNNorthd relies on OVNDBCluster Status object
for DBAddress and it is set only when OVNDBCluster is ready. Raise an Error if DBAddress is unset as
without it OVNNorthd or other consumers of OVNDBs
will not work.