### PR TITLE
Make sure PVCs get's deleted with OVNDBCluster

### DIFF
--- a/pkg/ovndbcluster/statefulset.go
+++ b/pkg/ovndbcluster/statefulset.go
@@ -122,12 +122,17 @@ func StatefulSet(
 		WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 		WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
 	}
+
+	blockOwnerDeletion := false
+	ownerRef := metav1.NewControllerRef(instance, instance.GroupVersionKind())
+	ownerRef.BlockOwnerDeletion = &blockOwnerDeletion
 	statefulset.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 		corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      instance.Name + PvcSuffixEtcOvn,
-				Namespace: instance.Namespace,
-				Labels:    labels,
+				Name:            instance.Name + PvcSuffixEtcOvn,
+				Namespace:       instance.Namespace,
+				Labels:          labels,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes: []corev1.PersistentVolumeAccessMode{


### PR DESCRIPTION
Set Owner reference in PVCs so those get's deleted along with OVNDBCluster CRs.

With Kubernetes v1.23 [alpha] this shouldn't be needed explicitly if PersistentVolumeClaimRetentionPolicy is set to Deleted.

Signed-off-by: Yatin Karel <ykarel@redhat.com>