### PR TITLE
Use stable/zed containers as default

### DIFF
--- a/api/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/api/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -45,8 +45,10 @@ spec:
             description: OVNDBClusterSpec defines the desired state of OVNDBCluster
             properties:
               containerImage:
+                default: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
                 type: string
               dbType:
+                default: NB
                 description: DBType - NB or SB
                 pattern: ^NB|SB$
                 type: string

--- a/api/bases/ovn.openstack.org_ovnnorthds.yaml
+++ b/api/bases/ovn.openstack.org_ovnnorthds.yaml
@@ -45,6 +45,7 @@ spec:
             description: OVNNorthdSpec defines the desired state of OVNNorthd
             properties:
               containerImage:
+                default: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
                 type: string
               logLevel:
                 default: info

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -25,9 +25,13 @@ import (
 
 // OVNDBClusterSpec defines the desired state of OVNDBCluster
 type OVNDBClusterSpec struct {
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo"
 	ContainerImage string `json:"containerImage,omitempty"`
 
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default="NB"
 	// +kubebuilder:validation:Pattern="^NB|SB$"
 	// DBType - NB or SB
 	DBType string `json:"dbType"`

--- a/api/v1beta1/ovnnorthd_types.go
+++ b/api/v1beta1/ovnnorthd_types.go
@@ -33,6 +33,8 @@ type Hash struct {
 
 // OVNNorthdSpec defines the desired state of OVNNorthd
 type OVNNorthdSpec struct {
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo"
 	ContainerImage string `json:"containerImage,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -45,8 +45,10 @@ spec:
             description: OVNDBClusterSpec defines the desired state of OVNDBCluster
             properties:
               containerImage:
+                default: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
                 type: string
               dbType:
+                default: NB
                 description: DBType - NB or SB
                 pattern: ^NB|SB$
                 type: string

--- a/config/crd/bases/ovn.openstack.org_ovnnorthds.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovnnorthds.yaml
@@ -45,6 +45,7 @@ spec:
             description: OVNNorthdSpec defines the desired state of OVNNorthd
             properties:
               containerImage:
+                default: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
                 type: string
               logLevel:
                 default: info

--- a/config/samples/ovn_v1beta1_ovndbcluster.yaml
+++ b/config/samples/ovn_v1beta1_ovndbcluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ovndbcluster-nb-sample
 spec:
   replicas: 1
-  containerImage: quay.io/tripleomastercentos9/openstack-ovn-nb-db-server:current-tripleo
+  containerImage: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
   logLevel: info
   storageRequest: 10G
   storageClass: local-storage
@@ -16,7 +16,7 @@ metadata:
   name: ovndbcluster-sb-sample
 spec:
   replicas: 1
-  containerImage: quay.io/tripleomastercentos9/openstack-ovn-sb-db-server:current-tripleo
+  containerImage: quay.io/tripleozedcentos9/openstack-ovn-sb-db-server:current-tripleo
   logLevel: info
   storageRequest: 10G
   storageClass: local-storage

--- a/config/samples/ovn_v1beta1_ovndbcluster_nb.yaml
+++ b/config/samples/ovn_v1beta1_ovndbcluster_nb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ovndbcluster-nb-sample
 spec:
   replicas: 1
-  containerImage: quay.io/tripleomastercentos9/openstack-ovn-nb-db-server:current-tripleo
+  containerImage: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
   logLevel: info
   storageRequest: 10G
   storageClass: local-storage

--- a/config/samples/ovn_v1beta1_ovndbcluster_sb.yaml
+++ b/config/samples/ovn_v1beta1_ovndbcluster_sb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ovndbcluster-sb-sample
 spec:
   replicas: 1
-  containerImage: quay.io/tripleomastercentos9/openstack-ovn-sb-db-server:current-tripleo
+  containerImage: quay.io/tripleozedcentos9/openstack-ovn-sb-db-server:current-tripleo
   logLevel: info
   storageRequest: 10G
   storageClass: local-storage

--- a/config/samples/ovn_v1beta1_ovnnorthd.yaml
+++ b/config/samples/ovn_v1beta1_ovnnorthd.yaml
@@ -4,5 +4,5 @@ metadata:
   name: ovnnorthd-sample
 spec:
   replicas: 1
-  containerImage: quay.io/tripleomastercentos9/openstack-ovn-northd:current-tripleo
+  containerImage: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
   logLevel: info


### PR DESCRIPTION
Also set DBType default to "NB" as using
nb container image as default for OVNDBCluster CRD.