### PR TITLE
Expose OVN North and SouthBound parameters in the API

### DIFF
--- a/api/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/api/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -52,6 +52,12 @@ spec:
                 description: DBType - NB or SB
                 pattern: ^NB|SB$
                 type: string
+              electionTimer:
+                default: 10000
+                description: OVN Northbound and Southbound RAFT db election timer
+                  to use on db creation (in milliseconds)
+                format: int32
+                type: integer
               logLevel:
                 default: info
                 description: LogLevel - Set log level info, dbg, emer etc
@@ -62,6 +68,12 @@ spec:
                 description: NodeSelector to target subset of worker nodes running
                   this service
                 type: object
+              probeIntervalToActive:
+                default: 60000
+                description: Active probe interval from standby to active ovsdb-server
+                  remote
+                format: int32
+                type: integer
               replicas:
                 default: 1
                 description: Replicas of OVN DBCluster to run

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -53,6 +53,16 @@ type OVNDBClusterSpec struct {
 	LogLevel string `json:"logLevel"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=10000
+	// OVN Northbound and Southbound RAFT db election timer to use on db creation (in milliseconds)
+	ElectionTimer int32 `json:"electionTimer"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60000
+	// Active probe interval from standby to active ovsdb-server remote
+	ProbeIntervalToActive int32 `json:"probeIntervalToActive"`
+
+	// +kubebuilder:validation:Optional
 	// Resources - Compute Resources required by this service (Limits/Requests).
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -52,6 +52,12 @@ spec:
                 description: DBType - NB or SB
                 pattern: ^NB|SB$
                 type: string
+              electionTimer:
+                default: 10000
+                description: OVN Northbound and Southbound RAFT db election timer
+                  to use on db creation (in milliseconds)
+                format: int32
+                type: integer
               logLevel:
                 default: info
                 description: LogLevel - Set log level info, dbg, emer etc
@@ -62,6 +68,12 @@ spec:
                 description: NodeSelector to target subset of worker nodes running
                   this service
                 type: object
+              probeIntervalToActive:
+                default: 60000
+                description: Active probe interval from standby to active ovsdb-server
+                  remote
+                format: int32
+                type: integer
               replicas:
                 default: 1
                 description: Replicas of OVN DBCluster to run

--- a/controllers/ovndbcluster_controller.go
+++ b/controllers/ovndbcluster_controller.go
@@ -446,6 +446,8 @@ func (r *OVNDBClusterReconciler) generateServiceConfigMaps(
 		templateParameters["DB_PORT"] = 6642
 		templateParameters["RAFT_PORT"] = 6644
 	}
+	templateParameters["OVN_ELECTION_TIMER"] = instance.Spec.ElectionTimer
+	templateParameters["OVN_PROBE_INTERVAL_TO_ACTIVE"] = instance.Spec.ProbeIntervalToActive
 	cms := []util.Template{
 		// ScriptsConfigMap
 		{

--- a/templates/ovndbcluster/bin/setup.sh
+++ b/templates/ovndbcluster/bin/setup.sh
@@ -27,6 +27,7 @@ if [[ "$(hostname)" != "{{ .SERVICE_NAME }}-0" ]]; then
     #ovsdb-tool join-cluster /etc/ovn/ovn${DB_TYPE}_db.db ${DB_NAME} tcp:$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local:${RAFT_PORT} tcp:{{ .SERVICE_NAME }}-0.{{ .SERVICE_NAME }}.openstack.svc.cluster.local:${RAFT_PORT}
     OPTS="--db-${DB_TYPE}-cluster-remote-proto=tcp --db-${DB_TYPE}-cluster-remote-addr={{ .SERVICE_NAME }}-0.{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-cluster-remote-port=${RAFT_PORT}"
 fi
-/usr/local/bin/start-${DB_TYPE}-db-server --db-${DB_TYPE}-create-insecure-remote=yes --db-${DB_TYPE}-election-timer=10000 --db-${DB_TYPE}-cluster-local-proto=tcp \
---db-${DB_TYPE}-cluster-local-addr=$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-cluster-local-port=${RAFT_PORT} \
---db-${DB_TYPE}-addr=$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-port=${DB_PORT} --ovn-${DB_TYPE}-log=-vfile:{{ .OVN_LOG_LEVEL }} ${OPTS}
+/usr/local/bin/start-${DB_TYPE}-db-server --db-${DB_TYPE}-create-insecure-remote=yes --db-${DB_TYPE}-election-timer={{ .OVN_ELECTION_TIMER }} --db-${DB_TYPE}-cluster-local-proto=tcp \
+--db-${DB_TYPE}-cluster-local-addr=$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-probe-interval-to-active={{ .OVN_PROBE_INTERVAL_TO_ACTIVE }} \
+--db-${DB_TYPE}-cluster-local-port=${RAFT_PORT} --db-${DB_TYPE}-addr=$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-port=${DB_PORT} \
+--ovn-${DB_TYPE}-log=-vfile:{{ .OVN_LOG_LEVEL }} ${OPTS}


### PR DESCRIPTION
This patch exposes 4 parameters:

--db-nb-probe-interval-to-active
--db-nb-election-timer
--db-sb-probe-interval-to-active
--db-sb-election-timer

in the API so that cloud operator can configure them. Default values are set to be the same as defaults for the ovn-ctl script (probe-interval-to-active) and as currently used (election-timer).