### PR TITLE
Allow Replicas >=1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.dll
 *.so
 *.dylib
-bin
+bin/*
 testbin/*
 
 # Test binary, build with `go test -c`

--- a/api/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/api/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -64,7 +64,7 @@ spec:
                 default: 1
                 description: Replicas of OVN DBCluster to run
                 format: int32
-                maximum: 1
+                maximum: 32
                 minimum: 0
                 type: integer
               resources:

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,6 +3,7 @@ module github.com/openstack-k8s-operators/ovn-operator/api
 go 1.18
 
 require (
+	github.com/go-logr/logr v1.2.3
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221124114404-c42a739be111
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4
@@ -15,13 +16,13 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -56,6 +56,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
@@ -81,6 +82,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
@@ -117,6 +119,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -130,6 +133,7 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -484,6 +488,7 @@ k8s.io/apimachinery v0.25.4 h1:CtXsuaitMESSu339tfhVXhQrPET+EiWnIY1rcurKnAc=
 k8s.io/apimachinery v0.25.4/go.mod h1:jaF9C/iPNM1FuLl7Zuy5b9v+n35HGSh6AQ4HYRkCqwo=
 k8s.io/client-go v0.25.4 h1:3RNRDffAkNU56M/a7gUfXaEzdhZlYhoW8dgViGy5fn8=
 k8s.io/client-go v0.25.4/go.mod h1:8trHCAC83XKY0wsBIpbirZU4NTUpbuhc2JnI7OruGZw=
+k8s.io/component-base v0.25.0 h1:haVKlLkPCFZhkcqB6WCvpVxftrg6+FK5x1ZuaIDaQ5Y=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.70.1 h1:7aaoSdahviPmR+XkS7FyxlkkXs6tHISSG03RxleQAVQ=
 k8s.io/klog/v2 v2.70.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -34,7 +34,7 @@ type OVNDBClusterSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
-	// +kubebuilder:validation:Maximum=1
+	// +kubebuilder:validation:Maximum=32
 	// +kubebuilder:validation:Minimum=0
 	// Replicas of OVN DBCluster to run
 	Replicas int32 `json:"replicas"`

--- a/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -64,7 +64,7 @@ spec:
                 default: 1
                 description: Replicas of OVN DBCluster to run
                 format: int32
-                maximum: 1
+                maximum: 32
                 minimum: 0
                 type: integer
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -132,8 +132,10 @@ rules:
   - ovndbclusters/status
   verbs:
   - get
+  - list
   - patch
   - update
+  - watch
 - apiGroups:
   - ovn.openstack.org
   resources:

--- a/controllers/ovnnorthd_controller.go
+++ b/controllers/ovnnorthd_controller.go
@@ -26,6 +26,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -68,6 +70,8 @@ func (r *OVNNorthdReconciler) GetScheme() *runtime.Scheme {
 //+kubebuilder:rbac:groups=ovn.openstack.org,resources=ovnnorthds,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ovn.openstack.org,resources=ovnnorthds/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=ovn.openstack.org,resources=ovnnorthds/finalizers,verbs=update
+//+kubebuilder:rbac:groups=ovn.openstack.org,resources=ovndbclusters,verbs=get;list;watch;
+//+kubebuilder:rbac:groups=ovn.openstack.org,resources=ovndbclusters/status,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch;update;delete;
 
@@ -156,6 +160,7 @@ func (r *OVNNorthdReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&ovnv1.OVNNorthd{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&appsv1.Deployment{}).
+		Watches(&source.Kind{Type: &ovnv1.OVNDBCluster{}}, handler.EnqueueRequestsFromMapFunc(ovnv1.OVNDBClusterNamespaceMapFunc(mgr.GetClient(), r.Log))).
 		Complete(r)
 }
 

--- a/pkg/ovndbcluster/const.go
+++ b/pkg/ovndbcluster/const.go
@@ -7,11 +7,8 @@ const (
 	// ServiceNameSB -
 	ServiceNameSB = "ovsdbserver-sb"
 
-	// KollaConfigOVNDBClusterNB -
-	KollaConfigOVNDBClusterNB = "/var/lib/config-data/ovn-dbcluster-nb.json"
-
-	// KollaConfigOVNDBClusterSB -
-	KollaConfigOVNDBClusterSB = "/var/lib/config-data/ovn-dbcluster-sb.json"
+	// KollaConfigOVNDBCluster -
+	KollaConfigOVNDBCluster = "/var/lib/config-data/ovn-dbcluster.json"
 
 	// ServiceAccountName -
 	ServiceAccountName = "ovn-operator-ovn"

--- a/pkg/ovndbcluster/service.go
+++ b/pkg/ovndbcluster/service.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Service - Service for conductor pod services
+// Service - Service for ovndbcluster per pod
 func Service(
 	serviceName string,
 	instance *ovnv1.OVNDBCluster,
@@ -42,6 +42,38 @@ func Service(
 					Protocol: corev1.ProtocolTCP,
 				},
 			},
+		},
+	}
+}
+
+// HeadlessService - Headless Service for ovndbcluster pods to get DNS names in pods
+func HeadlessService(
+	serviceName string,
+	instance *ovnv1.OVNDBCluster,
+	serviceLabels map[string]string,
+) *corev1.Service {
+	raftPortName := "north-raft"
+	var raftPort int32 = 6643
+	if instance.Spec.DBType == "SB" {
+		raftPortName = "south-raft"
+		raftPort = 6644
+	}
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: instance.Namespace,
+			Labels:    serviceLabels,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: serviceLabels,
+			Ports: []corev1.ServicePort{
+				{
+					Name:     raftPortName,
+					Port:     raftPort,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			ClusterIP: "None",
 		},
 	}
 }

--- a/pkg/ovndbcluster/volumes.go
+++ b/pkg/ovndbcluster/volumes.go
@@ -7,6 +7,7 @@ import corev1 "k8s.io/api/core/v1"
 //       mechanism.
 func GetDBClusterVolumes(name string) []corev1.Volume {
 	var config0640AccessMode int32 = 0640
+	var scriptsVolumeDefaultMode int32 = 0755
 
 	return []corev1.Volume{
 		{
@@ -22,6 +23,17 @@ func GetDBClusterVolumes(name string) []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/etc/localtime",
+				},
+			},
+		},
+		{
+			Name: "scripts",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					DefaultMode: &scriptsVolumeDefaultMode,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: name + "-scripts",
+					},
 				},
 			},
 		},
@@ -51,6 +63,11 @@ func GetDBClusterVolumeMounts(name string) []corev1.VolumeMount {
 		{
 			Name:      "etc-localtime",
 			MountPath: "/etc/localtime",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "scripts",
+			MountPath: "/usr/local/bin/container-scripts",
 			ReadOnly:  true,
 		},
 		{

--- a/templates/ovndbcluster/bin/cleanup.sh
+++ b/templates/ovndbcluster/bin/cleanup.sh
@@ -1,0 +1,25 @@
+#!/bin//bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+DB_NAME="OVN_Northbound"
+DB_TYPE="{{ .DB_TYPE }}"
+if [[ "${DB_TYPE}" == "sb" ]]; then
+    DB_NAME="OVN_Southbound"
+fi
+if [[ "$(hostname)" != "{{ .SERVICE_NAME }}-0" ]]; then
+  ovs-appctl -t /tmp/ovn${DB_TYPE}_db.ctl cluster/leave ${DB_NAME}
+fi

--- a/templates/ovndbcluster/bin/setup.sh
+++ b/templates/ovndbcluster/bin/setup.sh
@@ -1,0 +1,32 @@
+#!/bin//bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+DB_TYPE="{{ .DB_TYPE }}"
+DB_PORT="{{ .DB_PORT }}"
+RAFT_PORT="{{ .RAFT_PORT }}"
+OPTS=""
+DB_NAME="OVN_Northbound"
+if [[ "${DB_TYPE}" == "sb" ]]; then
+    DB_NAME="OVN_Southbound"
+fi
+if [[ "$(hostname)" != "{{ .SERVICE_NAME }}-0" ]]; then
+    rm -f /etc/ovn/ovn${DB_TYPE}_db.db
+    #ovsdb-tool join-cluster /etc/ovn/ovn${DB_TYPE}_db.db ${DB_NAME} tcp:$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local:${RAFT_PORT} tcp:{{ .SERVICE_NAME }}-0.{{ .SERVICE_NAME }}.openstack.svc.cluster.local:${RAFT_PORT}
+    OPTS="--db-${DB_TYPE}-cluster-remote-proto=tcp --db-${DB_TYPE}-cluster-remote-addr={{ .SERVICE_NAME }}-0.{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-cluster-remote-port=${RAFT_PORT}"
+fi
+/usr/local/bin/start-${DB_TYPE}-db-server --db-${DB_TYPE}-create-insecure-remote=yes --db-${DB_TYPE}-election-timer=10000 --db-${DB_TYPE}-cluster-local-proto=tcp \
+--db-${DB_TYPE}-cluster-local-addr=$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-cluster-local-port=${RAFT_PORT} \
+--db-${DB_TYPE}-addr=$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-port=${DB_PORT} --ovn-${DB_TYPE}-log=-vfile:{{ .OVN_LOG_LEVEL }} ${OPTS}

--- a/templates/ovndbcluster/config/ovn-dbcluster-nb.json
+++ b/templates/ovndbcluster/config/ovn-dbcluster-nb.json
@@ -1,3 +1,0 @@
-{
-  "command": "/usr/local/bin/start-nb-db-server --db-nb-create-insecure-remote=yes --db-nb-election-timer=10000 --db-nb-cluster-local-proto=tcp --db-nb-cluster-local-addr=0.0.0.0 --db-nb-cluster-local-port=6643 --db-nb-addr=0.0.0.0 --db-nb-port=6641 --ovn-nb-log=-vfile:{{ .OVN_LOG_LEVEL }}"
-}

--- a/templates/ovndbcluster/config/ovn-dbcluster-sb.json
+++ b/templates/ovndbcluster/config/ovn-dbcluster-sb.json
@@ -1,3 +1,0 @@
-{
-  "command": "/usr/local/bin/start-sb-db-server --db-sb-create-insecure-remote=yes --db-sb-election-timer=10000 --db-sb-cluster-local-proto=tcp --db-sb-cluster-local-addr=0.0.0.0 --db-sb-cluster-local-port=6644 --db-sb-addr=0.0.0.0 --db-sb-port=6642 --ovn-sb-log=-vfile:{{ .OVN_LOG_LEVEL }}"
-}

--- a/templates/ovndbcluster/config/ovn-dbcluster.json
+++ b/templates/ovndbcluster/config/ovn-dbcluster.json
@@ -1,0 +1,3 @@
+{
+  "command": "/usr/local/bin/container-scripts/setup.sh"
+}


### PR DESCRIPTION
- Add a headless service and set it in ServiceName field for statefulset to have FQDN in pods
- Add Watch to OVNDBCluster resources in OVNNorthd so pods get's updated when Status get's updated. It can also be used in other operators like neutron, ovs, octavia.
- Add "statefulset.kubernetes.io/pod-name" label to services per pod
- Cleanup leftover services with scale down
- Add cleanup script to be executed during pod termination.
- Add common setup script for both NB/SB DBClusters.