### PR TITLE
Change master branch to main

### DIFF
--- a/.github/workflows/build-ovn-operator.yaml
+++ b/.github/workflows/build-ovn-operator.yaml
@@ -49,8 +49,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -122,8 +122,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -159,8 +159,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 


### PR DESCRIPTION
In line with Red Hat's commitment to use inclusive language in our products. This change renames the default branch from master to main.