### PR TITLE
Add basic KUTTL tests for ovn operator

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,25 @@
+#
+# EXECUTION (from install_yamls repo root):
+#
+#   make ovn_kuttl
+#
+# ASSUMPTIONS:
+#
+# 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
+#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
+#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
+#    - chmod 755 /usr/local/bin/kubectl-kuttl
+# 2. An OCP 4.10+ CRC cluster with Podified Operators has been deployed
+# 3. CLI user has access to $KUBECONFIG
+# 4. The environment variable INSTALL_YAMLS is set to the the path of the
+#    install_yamls repo
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+reportFormat: JSON
+reportName: kuttl-test-ovn
+namespace: openstack
+timeout: 180
+parallel: 1
+suppress:
+  - events                     # Remove spammy event logs

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -1,0 +1,228 @@
+#
+# Check for:
+#
+# - 1 OVNNorthd CR
+# - 2 OVNDBCluster CR (ovndbcluster-nb-sample, ovndbcluster-sb-sample)
+# - Deployment with 1 Pod for OVNNorthd CR
+# - ovsdbserver-nb-0 Pod
+# - ovsdbserver-sb-0 Pod
+# - ovsdbserver-nb Service
+# - ovsdbserver-nb-0 Service
+# - ovsdbserver-sb Service
+# - ovsdbserver-sb-0 Service
+
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNNorthd
+metadata:
+  finalizers:
+  - OVNNorthd
+  name: ovnnorthd-sample
+  namespace: openstack
+spec:
+  containerImage: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
+  logLevel: info
+  replicas: 1
+status:
+  readyCount: 1
+---
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNDBCluster
+metadata:
+  finalizers:
+  - OVNDBCluster
+  name: ovndbcluster-nb-sample
+  namespace: openstack
+spec:
+  containerImage: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
+  dbType: NB
+  logLevel: info
+  replicas: 1
+  storageClass: local-storage
+  storageRequest: 10G
+status:
+  readyCount: 1
+---
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNDBCluster
+metadata:
+  finalizers:
+  - OVNDBCluster
+  name: ovndbcluster-sb-sample
+  namespace: openstack
+spec:
+  containerImage: quay.io/tripleozedcentos9/openstack-ovn-sb-db-server:current-tripleo
+  dbType: SB
+  logLevel: info
+  replicas: 1
+  storageClass: local-storage
+  storageRequest: 10G
+status:
+  readyCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ovn-northd
+  namespace: openstack
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        service: ovn-northd
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: service
+                  operator: In
+                  values:
+                  - ovn-northd
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      containers:
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        image: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+              - /usr/bin/pidof
+              - ovn-northd
+          failureThreshold: 3
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 5
+        securityContext:
+          runAsUser: 0
+        name: ovn-northd
+        readinessProbe:
+          exec:
+            command:
+              - /usr/bin/pidof
+              - ovn-northd
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources: {}
+      serviceAccount: ovn-operator-ovn
+      serviceAccountName: ovn-operator-ovn
+      restartPolicy: Always
+status:
+  availableReplicas: 1
+  replicas: 1
+---
+# the openshift annotations can't be checked through the deployment above
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  labels:
+    service: ovn-northd
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  labels:
+    service: ovsdbserver-nb
+  name: ovsdbserver-nb-0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  labels:
+    service: ovsdbserver-sb
+  name: ovsdbserver-sb-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ovsdbserver-nb
+  name: ovsdbserver-nb
+  namespace: openstack
+spec:
+  ports:
+    - name: north-raft
+      port: 6643
+      protocol: TCP
+      targetPort: 6643
+  selector:
+    service: ovsdbserver-nb
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ovsdbserver-nb
+    statefulset.kubernetes.io/pod-name: ovsdbserver-nb-0
+  name: ovsdbserver-nb-0
+  namespace: openstack
+spec:
+  ports:
+    - name: north
+      port: 6641
+      protocol: TCP
+      targetPort: 6641
+    - name: north-raft
+      port: 6643
+      protocol: TCP
+      targetPort: 6643
+  selector:
+    service: ovsdbserver-nb
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ovsdbserver-sb
+  name: ovsdbserver-sb
+  namespace: openstack
+spec:
+  ports:
+    - name: south-raft
+      port: 6644
+      protocol: TCP
+      targetPort: 6644
+  selector:
+    service: ovsdbserver-sb
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ovsdbserver-sb
+    statefulset.kubernetes.io/pod-name: ovsdbserver-sb-0
+  name: ovsdbserver-sb-0
+  namespace: openstack
+spec:
+  ports:
+    - name: south
+      port: 6642
+      protocol: TCP
+      targetPort: 6642
+    - name: south-raft
+      port: 6644
+      protocol: TCP
+      targetPort: 6644
+  selector:
+    service: ovsdbserver-sb
+  type: ClusterIP

--- a/tests/kuttl/common/cleanup-ovn.yaml
+++ b/tests/kuttl/common/cleanup-ovn.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      PWD=$INSTALL_YAMLS
+      make -C $INSTALL_YAMLS ovn_deploy_cleanup

--- a/tests/kuttl/common/deploy_ovn.yaml
+++ b/tests/kuttl/common/deploy_ovn.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      PWD=$INSTALL_YAMLS
+      make -C $INSTALL_YAMLS ovn_deploy

--- a/tests/kuttl/common/errors_cleanup_ovn.yaml
+++ b/tests/kuttl/common/errors_cleanup_ovn.yaml
@@ -1,0 +1,93 @@
+#
+# Check for:
+#
+# No OVNNorthd CR
+# No OVNDBCluster CR
+# No Deployment for OVNNorthd CR
+# No Pods in ovn Deployment
+# No OVN Services
+#
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNNorthd
+metadata:
+  finalizers:
+  - OVNNorthd
+  name: ovnnorthd-sample
+  namespace: openstack
+---
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNDBCluster
+metadata:
+  finalizers:
+  - OVNDBCluster
+  name: ovndbcluster-nb-sample
+  namespace: openstack
+---
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNDBCluster
+metadata:
+  finalizers:
+  - OVNDBCluster
+  name: ovndbcluster-sb-sample
+  namespace: openstack
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ovn-northd
+  namespace: openstack
+---
+# the openshift annotations can't be checked through the deployment above
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: ovn-northd
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: ovsdbserver-nb
+  name: ovsdbserver-nb-0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: ovsdbserver-sb
+  name: ovsdbserver-sb-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ovsdbserver-nb
+  name: ovsdbserver-nb
+  namespace: openstack
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ovsdbserver-nb
+    statefulset.kubernetes.io/pod-name: ovsdbserver-nb-0
+  name: ovsdbserver-nb-0
+  namespace: openstack
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ovsdbserver-sb
+  name: ovsdbserver-sb
+  namespace: openstack
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ovsdbserver-sb
+    statefulset.kubernetes.io/pod-name: ovsdbserver-sb-0
+  name: ovsdbserver-sb-0
+  namespace: openstack

--- a/tests/kuttl/tests/ovn_scale/01-assert.yaml
+++ b/tests/kuttl/tests/ovn_scale/01-assert.yaml
@@ -1,0 +1,1 @@
+../../common/assert_sample_deployment.yaml

--- a/tests/kuttl/tests/ovn_scale/01-deploy-ovn.yaml
+++ b/tests/kuttl/tests/ovn_scale/01-deploy-ovn.yaml
@@ -1,0 +1,1 @@
+../../common/deploy_ovn.yaml

--- a/tests/kuttl/tests/ovn_scale/02-assert.yaml
+++ b/tests/kuttl/tests/ovn_scale/02-assert.yaml
@@ -1,0 +1,28 @@
+#
+# Check for:
+#
+# - 1 OVNNorthd CR
+# - 3 Pods for OVNNorthd CR
+#
+
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNNorthd
+metadata:
+  finalizers:
+  - OVNNorthd
+  name: ovnnorthd-sample
+  namespace: openstack
+spec:
+  replicas: 3
+status:
+  readyCount: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ovn-northd
+  namespace: openstack
+spec:
+  replicas: 3
+status:
+  availableReplicas: 3

--- a/tests/kuttl/tests/ovn_scale/02-scale-ovnnorthd.yaml
+++ b/tests/kuttl/tests/ovn_scale/02-scale-ovnnorthd.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch OVNNorthd -n openstack ovnnorthd-sample --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":3}]'

--- a/tests/kuttl/tests/ovn_scale/03-assert.yaml
+++ b/tests/kuttl/tests/ovn_scale/03-assert.yaml
@@ -1,0 +1,28 @@
+#
+# Check for:
+#
+# - 1 OVNNorthd CR
+# - 1 Pods for OVNNorthd CR
+#
+
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNNorthd
+metadata:
+  finalizers:
+  - OVNNorthd
+  name: ovnnorthd-sample
+  namespace: openstack
+spec:
+  replicas: 1
+status:
+  readyCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ovn-northd
+  namespace: openstack
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1

--- a/tests/kuttl/tests/ovn_scale/03-scale-down-ovnnorthd.yaml
+++ b/tests/kuttl/tests/ovn_scale/03-scale-down-ovnnorthd.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch OVNNorthd -n openstack ovnnorthd-sample --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":1}]'

--- a/tests/kuttl/tests/ovn_scale/04-assert.yaml
+++ b/tests/kuttl/tests/ovn_scale/04-assert.yaml
@@ -1,0 +1,24 @@
+#
+# Check for:
+#
+# - 1 OVNNorthd CR with no replicas
+# - 0 Pods for OVNNorthd CR
+#
+
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNNorthd
+metadata:
+  finalizers:
+  - OVNNorthd
+  name: ovnnorthd-sample
+  namespace: openstack
+spec:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ovn-northd
+  namespace: openstack
+spec:
+  replicas: 0

--- a/tests/kuttl/tests/ovn_scale/04-errors.yaml
+++ b/tests/kuttl/tests/ovn_scale/04-errors.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: anyuid
+  labels:
+    service: ovn

--- a/tests/kuttl/tests/ovn_scale/04-scale-down-zero-ovnnorthd.yaml
+++ b/tests/kuttl/tests/ovn_scale/04-scale-down-zero-ovnnorthd.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch OVNNorthd -n openstack ovnnorthd-sample --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":0}]'

--- a/tests/kuttl/tests/ovn_scale/05-cleanup-ovn.yaml
+++ b/tests/kuttl/tests/ovn_scale/05-cleanup-ovn.yaml
@@ -1,0 +1,1 @@
+../../common/cleanup-ovn.yaml

--- a/tests/kuttl/tests/ovn_scale/05-errors.yaml
+++ b/tests/kuttl/tests/ovn_scale/05-errors.yaml
@@ -1,0 +1,1 @@
+../../common/errors_cleanup_ovn.yaml


### PR DESCRIPTION
These tests cover basic operations: deployment, scaling up, scaling down
and clean up. These tests use code from the install_yamls repo to reuse
some operations like the deployment of the ovn operators, as well as the
cleanup from previous runs.

Test are thought to be reun from the `install_yamls` repo, see the following
PR: https://github.com/openstack-k8s-operators/install_yamls/pull/93

There are three ways to run the tests:
1) Run `make ovn_kuttl`, this will only work if you want to run the test
from the master branch.
2) Run `make ovn_kuttl OVN_REPO=ovn-operator._repo_url
OVN_BRANCH=branch_name` this is useful if you want to run the tests from
a fork
3) Run `make ovn_kuttl
OVN_KUTTL_CONF=/path/to/ovn-operator/kuttl-test.yaml
OVN_KUTTL_DIR=/path/to/ovn-operator/tests/kuttl/tests/` this is
useful to run local changes to the tests
