### PR TITLE
Allow to set inactivity probe

### DIFF
--- a/api/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/api/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -58,6 +58,11 @@ spec:
                   to use on db creation (in milliseconds)
                 format: int32
                 type: integer
+              inactivityProbe:
+                default: 60000
+                description: Probe interval for the OVSDB session (in milliseconds)
+                format: int32
+                type: integer
               logLevel:
                 default: info
                 description: LogLevel - Set log level info, dbg, emer etc

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -59,6 +59,11 @@ type OVNDBClusterSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=60000
+	// Probe interval for the OVSDB session (in milliseconds)
+	InactivityProbe int32 `json:"inactivityProbe"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60000
 	// Active probe interval from standby to active ovsdb-server remote
 	ProbeIntervalToActive int32 `json:"probeIntervalToActive"`
 

--- a/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -58,6 +58,11 @@ spec:
                   to use on db creation (in milliseconds)
                 format: int32
                 type: integer
+              inactivityProbe:
+                default: 60000
+                description: Probe interval for the OVSDB session (in milliseconds)
+                format: int32
+                type: integer
               logLevel:
                 default: info
                 description: LogLevel - Set log level info, dbg, emer etc

--- a/controllers/ovndbcluster_controller.go
+++ b/controllers/ovndbcluster_controller.go
@@ -446,6 +446,7 @@ func (r *OVNDBClusterReconciler) generateServiceConfigMaps(
 		templateParameters["RAFT_PORT"] = 6644
 	}
 	templateParameters["OVN_ELECTION_TIMER"] = instance.Spec.ElectionTimer
+	templateParameters["OVN_INACTIVITY_PROBE"] = instance.Spec.InactivityProbe
 	templateParameters["OVN_PROBE_INTERVAL_TO_ACTIVE"] = instance.Spec.ProbeIntervalToActive
 	cms := []util.Template{
 		// ScriptsConfigMap

--- a/pkg/ovndbcluster/statefulset.go
+++ b/pkg/ovndbcluster/statefulset.go
@@ -66,6 +66,13 @@ func StatefulSet(
 	readinessProbe.Exec = livenessProbe.Exec
 
 	lifecycle := &corev1.Lifecycle{
+		PostStart: &corev1.LifecycleHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{
+					"/usr/local/bin/container-scripts/settings.sh",
+				},
+			},
+		},
 		PreStop: &corev1.LifecycleHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{

--- a/templates/ovndbcluster/bin/settings.sh
+++ b/templates/ovndbcluster/bin/settings.sh
@@ -1,0 +1,32 @@
+#!/bin//bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+DB_TYPE="{{ .DB_TYPE }}"
+DB_PORT="{{ .DB_PORT }}"
+
+exec 1>/proc/1/fd/1 2>&1
+
+if [[ "$(hostname)" == "{{ .SERVICE_NAME }}-0" ]]; then
+	while [ ! -S /tmp/ovn${DB_TYPE}_db.ctl ]; do
+		echo DB Server Not ready, waiting
+		sleep 1
+	done
+
+	while [ "$(ovn-${DB_TYPE}ctl --no-leader-only get connection . inactivity_probe)" != "{{ .OVN_INACTIVITY_PROBE }}" ]; do
+		ovn-${DB_TYPE}ctl --no-leader-only --inactivity-probe={{ .OVN_INACTIVITY_PROBE }} set-connection ptcp:${DB_PORT}:0.0.0.0
+	done
+	ovn-${DB_TYPE}ctl --no-leader-only list connection
+fi

--- a/templates/ovndbcluster/bin/setup.sh
+++ b/templates/ovndbcluster/bin/setup.sh
@@ -27,7 +27,7 @@ if [[ "$(hostname)" != "{{ .SERVICE_NAME }}-0" ]]; then
     #ovsdb-tool join-cluster /etc/ovn/ovn${DB_TYPE}_db.db ${DB_NAME} tcp:$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local:${RAFT_PORT} tcp:{{ .SERVICE_NAME }}-0.{{ .SERVICE_NAME }}.openstack.svc.cluster.local:${RAFT_PORT}
     OPTS="--db-${DB_TYPE}-cluster-remote-proto=tcp --db-${DB_TYPE}-cluster-remote-addr={{ .SERVICE_NAME }}-0.{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-cluster-remote-port=${RAFT_PORT}"
 fi
-/usr/local/bin/start-${DB_TYPE}-db-server --db-${DB_TYPE}-create-insecure-remote=yes --db-${DB_TYPE}-election-timer={{ .OVN_ELECTION_TIMER }} --db-${DB_TYPE}-cluster-local-proto=tcp \
+/usr/local/bin/start-${DB_TYPE}-db-server --db-${DB_TYPE}-election-timer={{ .OVN_ELECTION_TIMER }} --db-${DB_TYPE}-cluster-local-proto=tcp \
 --db-${DB_TYPE}-cluster-local-addr=$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-probe-interval-to-active={{ .OVN_PROBE_INTERVAL_TO_ACTIVE }} \
 --db-${DB_TYPE}-cluster-local-port=${RAFT_PORT} --db-${DB_TYPE}-addr=$(hostname).{{ .SERVICE_NAME }}.openstack.svc.cluster.local --db-${DB_TYPE}-port=${DB_PORT} \
 --ovn-${DB_TYPE}-log=-vfile:{{ .OVN_LOG_LEVEL }} ${OPTS}


### PR DESCRIPTION
Default inactivity-probe(5s) for ovsdb sessions is too low, this patch bumps it to 60seconds and adds a
Spec parameter to allow configuring it.