### PR TITLE
Expose both Pod's and NAD's IPs as DBAddresses

### DIFF
--- a/api/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/api/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -179,13 +179,17 @@ spec:
                   type: object
                 type: array
               dbAddress:
-                description: DBAddress -
+                description: DBAddress - DB IP address used by external nodes
                 type: string
               hash:
                 additionalProperties:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              internalDbAddress:
+                description: InternalDBAddress - DB IP address used by other Pods
+                  in the cluster
+                type: string
               networkAttachments:
                 additionalProperties:
                   items:

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -100,8 +100,11 @@ type OVNDBClusterStatus struct {
 	// RaftAddress -
 	RaftAddress string `json:"raftAddress,omitempty"`
 
-	// DBAddress -
+	// DBAddress - DB IP address used by external nodes
 	DBAddress string `json:"dbAddress,omitempty"`
+
+	// InternalDBAddress - DB IP address used by other Pods in the cluster
+	InternalDBAddress string `json:"internalDbAddress,omitempty"`
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`

--- a/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -179,13 +179,17 @@ spec:
                   type: object
                 type: array
               dbAddress:
-                description: DBAddress -
+                description: DBAddress - DB IP address used by external nodes
                 type: string
               hash:
                 additionalProperties:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              internalDbAddress:
+                description: InternalDBAddress - DB IP address used by other Pods
+                  in the cluster
+                type: string
               networkAttachments:
                 additionalProperties:
                   items:

--- a/controllers/ovnnorthd_controller.go
+++ b/controllers/ovnnorthd_controller.go
@@ -390,8 +390,8 @@ func (r *OVNNorthdReconciler) generateServiceConfigMaps(
 	}
 	templateParameters := make(map[string]interface{})
 
-	templateParameters["NBConnection"] = dbmap["NB"]
-	templateParameters["SBConnection"] = dbmap["SB"]
+	templateParameters["NBConnection"] = dbmap["internal-NB"]
+	templateParameters["SBConnection"] = dbmap["internal-SB"]
 	templateParameters["OVN_LOG_LEVEL"] = instance.Spec.LogLevel
 
 	cms := []util.Template{


### PR DESCRIPTION
Both IP addresses may be needed as ovn-controller running inside POD (OVS) on control plane should use POD's network to connect to the OVN DBs and EDPM nodes should use internalapi network which is plugged as NAD to the OVN DB pods.