### PR TITLE
Update "#!/bin//bash" to "#!/usr/bin/env bash"

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 CLUSTER_BUNDLE_FILE="bundle/manifests/ovn-operator.clusterserviceversion.yaml"

--- a/.github/create_opm_index.sh
+++ b/.github/create_opm_index.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "Creating operator index image"

--- a/templates/ovndbcluster/bin/cleanup.sh
+++ b/templates/ovndbcluster/bin/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin//bash
+#!/usr/bin/env bash
 #
 # Copyright 2022 Red Hat Inc.
 #

--- a/templates/ovndbcluster/bin/settings.sh
+++ b/templates/ovndbcluster/bin/settings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2022 Red Hat Inc.
 #

--- a/templates/ovndbcluster/bin/setup.sh
+++ b/templates/ovndbcluster/bin/setup.sh
@@ -1,4 +1,4 @@
-#!/bin//bash
+#!/usr/bin/env bash
 #
 # Copyright 2022 Red Hat Inc.
 #


### PR DESCRIPTION
Inside the `ovsdbserver-nb-0` pod we can see the command shell path has a typeo:

```
[root@ovsdbserver-nb-0 /]# ps -elf
F S UID          PID    PPID  C PRI  NI ADDR SZ WCHAN  STIME TTY          TIME CMD
4 S root           1       0  0  80   0 -  1811 -      Mar30 ?        00:00:00 /bin//bash /usr/local/bin/container-scripts/setup.sh
```

I've also updated the others in this repo that didn't have the typeo to be consistant.  