### PR TITLE
Fix make tidy not to depend on ./bin path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,11 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+APIPATH ?= $(shell pwd)/api
 .PHONY: tidy
 tidy: fmt
 	go mod tidy; \
-	pushd "$(LOCALBIN)/../api"; \
+	pushd $(APIPATH); \
 	go mod tidy; \
 	popd
 


### PR DESCRIPTION
We should not assume that ./bin exists as it is not part of the git repository but created dynamically.