### PR TITLE
Remove install_yamls dependency for kuttl tests

### DIFF
--- a/tests/kuttl/common/cleanup-ovn.yaml
+++ b/tests/kuttl/common/cleanup-ovn.yaml
@@ -1,6 +1,15 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-commands:
-  - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS ovn_deploy_cleanup
+delete:
+- apiVersion: ovn.openstack.org/v1beta1
+  kind: OVNDBCluster
+  name: ovndbcluster-nb-sample
+  namespace: openstack
+- apiVersion: ovn.openstack.org/v1beta1
+  kind: OVNDBCluster
+  name: ovndbcluster-sb-sample
+  namespace: openstack
+- apiVersion: ovn.openstack.org/v1beta1
+  kind: OVNNorthd
+  name: ovnnorthd-sample
+  namespace: openstack

--- a/tests/kuttl/common/deploy_ovn.yaml
+++ b/tests/kuttl/common/deploy_ovn.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-commands:
-  - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS ovn_deploy
+apply:
+- ../../../../config/samples/ovn_v1beta1_ovndbcluster.yaml
+- ../../../../config/samples/ovn_v1beta1_ovnnorthd.yaml


### PR DESCRIPTION
Instead of using install_yamls targets for deploying and cleaning up
ovn, use the CR sample from config/samples. This removes a possible
circular dependency issue when using install_yamls to run the jobs and
to run some test steps.
