### PR TITLE
Differentiate NB and SB default images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,8 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete mutatingwebhookconfiguration/movnnorthd.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export OVN_DBCLUSTER_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
+run-with-webhook: export OVN_NB_DBCLUSTER_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
+run-with-webhook: export OVN_SB_DBCLUSTER_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ovn-sb-db-server:current-tripleo
 run-with-webhook: export OVN_NORTHD_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -23,6 +23,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// NBDBType - Northbound database type
+	NBDBType = "NB"
+	// SBDBType - Southbound database type
+	SBDBType = "SB"
+)
+
 // OVNDBClusterSpec defines the desired state of OVNDBCluster
 type OVNDBClusterSpec struct {
 

--- a/api/v1beta1/ovndbcluster_webhook.go
+++ b/api/v1beta1/ovndbcluster_webhook.go
@@ -31,7 +31,8 @@ import (
 
 // OVNDBClusterDefaults -
 type OVNDBClusterDefaults struct {
-	ContainerImageURL string
+	NBContainerImageURL string
+	SBContainerImageURL string
 }
 
 var ovnDbClusterDefaults OVNDBClusterDefaults
@@ -66,7 +67,11 @@ func (r *OVNDBCluster) Default() {
 // Default - set defaults for this OVNDBCluster spec
 func (spec *OVNDBClusterSpec) Default() {
 	if spec.ContainerImage == "" {
-		spec.ContainerImage = ovnDbClusterDefaults.ContainerImageURL
+		if spec.DBType == NBDBType {
+			spec.ContainerImage = ovnDbClusterDefaults.NBContainerImageURL
+		} else if spec.DBType == SBDBType {
+			spec.ContainerImage = ovnDbClusterDefaults.SBContainerImageURL
+		}
 	}
 }
 

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,7 +11,9 @@ spec:
       containers:
       - name: manager
         env:
-        - name: OVN_DBCLUSTER_IMAGE_URL_DEFAULT
+        - name: OVN_NB_DBCLUSTER_IMAGE_URL_DEFAULT
           value: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
+        - name: OVN_SB_DBCLUSTER_IMAGE_URL_DEFAULT
+          value: quay.io/tripleozedcentos9/openstack-ovn-sb-db-server:current-tripleo
         - name: OVN_NORTHD_IMAGE_URL_DEFAULT
           value: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo

--- a/main.go
+++ b/main.go
@@ -117,7 +117,8 @@ func main() {
 
 	// Acquire environmental defaults and initialize OVNDBCluster defaults with them
 	ovnDbClusterDefaults := ovnv1.OVNDBClusterDefaults{
-		ContainerImageURL: os.Getenv("OVN_DBCLUSTER_IMAGE_URL_DEFAULT"),
+		NBContainerImageURL: os.Getenv("OVN_NB_DBCLUSTER_IMAGE_URL_DEFAULT"),
+		SBContainerImageURL: os.Getenv("OVN_SB_DBCLUSTER_IMAGE_URL_DEFAULT"),
 	}
 
 	ovnv1.SetupOVNDBClusterDefaults(ovnDbClusterDefaults)


### PR DESCRIPTION
The initial defaulting webhooks for OVN did not properly distinguish between container images for NB and SB DB clusters.  This corrects that.