### PR TITLE
Fix OVNController KClient nil-pointer error

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,8 +113,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.OVNControllerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:  mgr.GetClient(),
+		Kclient: kclient,
+		Scheme:  mgr.GetScheme(),
+		Log:     ctrl.Log.WithName("controllers").WithName("OVNController"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OVNController")
 		os.Exit(1)


### PR DESCRIPTION
Fixes an error we've recently been seeing:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc0 pc=0x15fee3a]

goroutine 432 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:119 +0x1fa
panic({0x17db860, 0x28df0b0})
	/usr/local/go/src/runtime/panic.go:884 +0x212
github.com/openstack-k8s-operators/lib-common/modules/common/pod.GetPodListWithLabel({0x1c83818, 0xc000ce01e0}, 0xc000187550, {0xc0012b40b0, 0x9}, 0xc001b675f0)
	/go/pkg/mod/github.com/openstack-k8s-operators/lib-common/modules/common@v0.0.0-20230526163116-6df6d982a172/pod/pod.go:42 +0x7a
github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment.VerifyNetworkStatusFromAnnotation({0x1c83818, 0xc000ce01e0}, 0xc000187550, {0xc000a0bef0, 0x1, 0xc0012b40b0?}, 0x9?, 0x1)
	/go/pkg/mod/github.com/openstack-k8s-operators/lib-common/modules/common@v0.0.0-20230526163116-6df6d982a172/networkattachment/networkattachment.go:112 +0xc5
```