### PR TITLE
set enable-chassis-as-gw on controllers by default

### DIFF
--- a/api/bases/ovn.openstack.org_ovncontrollers.yaml
+++ b/api/bases/ovn.openstack.org_ovncontrollers.yaml
@@ -40,6 +40,7 @@ spec:
                   OVS external-ids table
                 properties:
                   enable-chassis-as-gateway:
+                    default: true
                     type: boolean
                   ovn-bridge:
                     type: string

--- a/api/v1beta1/ovncontroller_types.go
+++ b/api/v1beta1/ovncontroller_types.go
@@ -128,7 +128,9 @@ type OVSExternalIDs struct {
 	// OvnEncapType - geneve or vxlan
 	OvnEncapType string `json:"ovn-encap-type"`
 
-	EnableChassisAsGateway bool `json:"enable-chassis-as-gateway,omitempty" optional:"true"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=true
+	EnableChassisAsGateway bool `json:"enable-chassis-as-gateway"`
 }
 
 // RbacConditionsSet - set the conditions for the rbac object

--- a/config/crd/bases/ovn.openstack.org_ovncontrollers.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovncontrollers.yaml
@@ -40,6 +40,7 @@ spec:
                   OVS external-ids table
                 properties:
                   enable-chassis-as-gateway:
+                    default: true
                     type: boolean
                   ovn-bridge:
                     type: string

--- a/templates/ovncontroller/bin/init.sh
+++ b/templates/ovncontroller/bin/init.sh
@@ -19,7 +19,7 @@ OvnBridge=${OvnBridge:-"br-int"}
 OvnRemote=${OvnRemote:-"tcp:127.0.0.1:6642"}
 OvnEncapType=${OvnEncapType:-"geneve"}
 OvnEncapNIC=${OvnEncapNIC:="eth0"}
-EnableChassisAsGateway=${EnableChassisAsGateway:-false}
+EnableChassisAsGateway=${EnableChassisAsGateway:-true}
 PhysicalNetworks=${PhysicalNetworks:-""}
 OvnHostName=${OvnHostName:-""}
 OvnEncapIP=$(ip -o addr show dev ${OvnEncapNIC} scope global | awk '{print $4}' | cut -d/ -f1)


### PR DESCRIPTION
As part of [1] the enable-chassis-as-gw flag has been removed by default from the computes. Now this patch changes the default on the controllers to have it enabled so that the gw ports as hosted on the controllers instead of the computes by default.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/178