### PR TITLE
Use constant to define restart policy

### DIFF
--- a/pkg/ovncontroller/configjob.go
+++ b/pkg/ovncontroller/configjob.go
@@ -84,7 +84,7 @@ func ConfigJob(
 					TTLSecondsAfterFinished: &jobTTLAfterFinished,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							RestartPolicy:      "OnFailure",
+							RestartPolicy:      corev1.RestartPolicyOnFailure,
 							ServiceAccountName: instance.RbacResourceName(),
 							Containers: []corev1.Container{
 								{


### PR DESCRIPTION
... instead of hard-coding the string value.