### PR TITLE
CSV: Set operator-type: non-standalone

### DIFF
--- a/config/manifests/bases/ovn-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ovn-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.operatorframework.io/operator-type: non-standalone
   name: ovn-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This should hide the ovn package/bundle in the OpenShift console as we only want the main OpenStack operator to show up there.