### PR TITLE
Fix interface name usage with network isolation

### DIFF
--- a/pkg/ovncontroller/utils.go
+++ b/pkg/ovncontroller/utils.go
@@ -29,8 +29,8 @@ func getPhysicalNetworks(
 ) string {
 	// NOTE(slaweq): to make things easier, each physical bridge will have
 	//               the same name as "br-<physical network>"
-	// NOTE(slaweq): interface names aren't important as inside Pod they will have
-	//               names like "net1, net2..." so only order is important really
+	// NOTE(slaweq): interface names aren't important as inside Pod they will be
+	//               named based on the NicMappings keys
 	return strings.Join(
 		maps.Keys(instance.Spec.NicMappings), " ",
 	)

--- a/templates/ovncontroller/bin/init.sh
+++ b/templates/ovncontroller/bin/init.sh
@@ -53,12 +53,10 @@ function configure_external_ids {
 # Configure bridge mappings and physical bridges
 function configure_physical_networks {
     local OvnBridgeMappings=""
-    local net_number=1
     for physicalNetwork in ${PhysicalNetworks}; do
         br_name="br-${physicalNetwork}"
         ovs-vsctl --may-exist add-br ${br_name}
-        ovs-vsctl --may-exist add-port ${br_name} net${net_number}
-        net_number=$(( net_number+1 ))
+        ovs-vsctl --may-exist add-port ${br_name} ${physicalNetwork}
         bridgeMapping="${physicalNetwork}:${br_name}"
         if [ -z "$OvnBridgeMappings"]; then
             OvnBridgeMappings=$bridgeMapping


### PR DESCRIPTION
Since [1] interfaces are no longer named net1, net2 etc but instead named based on networkattachment definition name.

[1] https://github.com/openstack-k8s-operators/lib-common/commit/230d45bb