### PR TITLE
Fix OVNController ConfigJob waiting

### DIFF
--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -443,7 +443,7 @@ func (r *OVNControllerReconciler) reconcileNormal(ctx context.Context, instance 
 				jobDef,
 				configHashKey,
 				false,
-				5,
+				time.Duration(5)*time.Second,
 				configHash,
 			)
 			ctrlResult, err = configJob.DoJob(ctx, helper)


### PR DESCRIPTION
The timeout argument is in nanoseconds, so we should multiply it by time.Second to wait 5 seconds instead of 5 nanoseconds.