### PR TITLE
Use consistent commands to copy manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
-	rm -rf api/bases/ && cp -a config/crd/bases api/
+	rm -f api/bases/* && cp -a config/crd/bases api/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
https://github.com/openshift/release/pull/41169 was merged which resolves the permission problem in CI. Thus we can revert the change and use the consistent command.