### PR TITLE
switch to structured logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"strings"
@@ -98,8 +99,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OVNNorthd"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, context.Background()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OVNNorthd")
 		os.Exit(1)
 	}
@@ -107,7 +107,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Kclient: kclient,
 		Scheme:  mgr.GetScheme(),
-		Log:     ctrl.Log.WithName("controllers").WithName("OVNDBCluster"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OVNDBCluster")
 		os.Exit(1)
@@ -116,8 +115,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Kclient: kclient,
 		Scheme:  mgr.GetScheme(),
-		Log:     ctrl.Log.WithName("controllers").WithName("OVNController"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, context.Background()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OVNController")
 		os.Exit(1)
 	}

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -150,15 +150,13 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OVNNorthd"),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, context.Background())
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.OVNDBClusterReconciler{
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OVNDBCluster"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -166,8 +164,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OVNController"),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, context.Background())
 	Expect(err).ToNot(HaveOccurred())
 
 	// Acquire environmental defaults and initialize operator defaults with them


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.

before :

`2023-05-18T01:53:14+03:00 INFO  controllers.KeystoneAPI Reconciled Service init successfully`

after:

`2023-10-19T10:41:34.351+0300    INFO    Controllers.OVNController       Reconciling Service upgrade     {"controller": "ovncontroller", "controllerGroup": "ovn.openstack.org", "controllerKind": "OVNController", "OVNController": {"name":"ovncontroller","namespace":"openstack"}, "namespace": "openstack", "name": "ovncontroller", "reconcileID": "b8e9495c-14f3-461d-ad0e-0e03f193bf4f"}
`

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.


