### PR TITLE
[local webhook] Adjust firewall only if binary exists

### DIFF
--- a/hack/configure_local_webhook.sh
+++ b/hack/configure_local_webhook.sh
@@ -7,8 +7,10 @@ CRC_IP=${CRC_IP:-$(/sbin/ip -o -4 addr list crc | awk '{print $4}' | cut -d/ -f1
 FIREWALL_ZONE=${FIREWALL_ZONE:-"libvirt"}
 
 #Open 9443
-sudo firewall-cmd --zone=${FIREWALL_ZONE} --add-port=9443/tcp
-sudo firewall-cmd --runtime-to-permanent
+if command -v firewall-cmd &> /dev/null; then
+    sudo firewall-cmd --zone=${FIREWALL_ZONE} --add-port=9443/tcp
+    sudo firewall-cmd --runtime-to-permanent
+fi
 
 # Generate the certs and the ca bundle
 if [ "$SKIP_CERT" = false ] ; then


### PR DESCRIPTION
The script currently fails on systems where
firewall-cmd binary do not exist. Let's set the
firewall rules only when binary exists.