### PR TITLE
Support disconnected network environments

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,69 +1,13 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/ovn-operator.clusterserviceversion.yaml"
-
-echo "Creating ovn operator bundle"
+echo "Creating OVN operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/ovn-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-    digest_image=""
-    echo "CSV line: ${csv_image}"
-
-    # case where @ is in the csv_image image
-    if [[ "$csv_image" =~ .*"@".* ]]; then
-        delimeter='@'
-    else
-        delimeter=':'
-    fi
-
-    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-    if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-        echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-        sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-    else
-        digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-        echo "Base image: $base_image"
-        if [ -n "$digest_image" ]; then
-            echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-            sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-        else
-            echo "$base_image${delimeter}$tag_image not changed"
-        fi
-    fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -22,23 +22,23 @@ import "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize OVNDBCluster defaults with them
 	ovnDbClusterDefaults := OVNDBClusterDefaults{
-		NBContainerImageURL: util.GetEnvVar("OVN_NB_DBCLUSTER_IMAGE_URL_DEFAULT", OvnNBContainerImage),
-		SBContainerImageURL: util.GetEnvVar("OVN_SB_DBCLUSTER_IMAGE_URL_DEFAULT", OvnSBContainerImage),
+		NBContainerImageURL: util.GetEnvVar("RELATED_IMAGE_OVN_NB_DBCLUSTER_IMAGE_URL_DEFAULT", OvnNBContainerImage),
+		SBContainerImageURL: util.GetEnvVar("RELATED_IMAGE_OVN_SB_DBCLUSTER_IMAGE_URL_DEFAULT", OvnSBContainerImage),
 	}
 
 	SetupOVNDBClusterDefaults(ovnDbClusterDefaults)
 
 	// Acquire environmental defaults and initialize OVNNorthd defaults with them
 	ovnNorthdDefaults := OVNNorthdDefaults{
-		ContainerImageURL: util.GetEnvVar("OVN_NORTHD_IMAGE_URL_DEFAULT", OvnNorthdContainerImage),
+		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_OVN_NORTHD_IMAGE_URL_DEFAULT", OvnNorthdContainerImage),
 	}
 
 	SetupOVNNorthdDefaults(ovnNorthdDefaults)
 
 	// Acquire environmental defaults and initialize OVNController defaults with them
 	ovnControllerDefaults := OvnControllerDefaults{
-		OvsContainerImageURL:           util.GetEnvVar("OVN_CONTROLLER_OVS_IMAGE_URL_DEFAULT", OvnControllerOvsContainerImage),
-		OvnControllerContainerImageURL: util.GetEnvVar("OVN_CONTROLLER_IMAGE_URL_DEFAULT", OvnControllerContainerImage),
+		OvsContainerImageURL:           util.GetEnvVar("RELATED_IMAGE_OVN_CONTROLLER_OVS_IMAGE_URL_DEFAULT", OvnControllerOvsContainerImage),
+		OvnControllerContainerImageURL: util.GetEnvVar("RELATED_IMAGE_OVN_CONTROLLER_IMAGE_URL_DEFAULT", OvnControllerContainerImage),
 	}
 
 	SetupOVNControllerDefaults(ovnControllerDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,13 +11,13 @@ spec:
       containers:
       - name: manager
         env:
-        - name: OVN_NB_DBCLUSTER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_OVN_NB_DBCLUSTER_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ovn-nb-db-server:current-podified
-        - name: OVN_SB_DBCLUSTER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_OVN_SB_DBCLUSTER_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ovn-sb-db-server:current-podified
-        - name: OVN_NORTHD_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_OVN_NORTHD_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ovn-northd:current-podified
-        - name: OVN_CONTROLLER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_OVN_CONTROLLER_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
-        - name: OVN_CONTROLLER_OVS_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_OVN_CONTROLLER_OVS_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified

--- a/config/manifests/bases/ovn-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ovn-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: ovn-operator.v0.0.0
   namespace: placeholder
@@ -11,6 +12,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: OVNController is the Schema for the ovncontrollers API
+      displayName: OVNController
+      kind: OVNController
+      name: ovncontrollers.ovn.openstack.org
+      version: v1beta1
     - description: OVNDBCluster is the Schema for the ovndbclusters API
       displayName: OVNDBCluster
       kind: OVNDBCluster

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -22,7 +22,6 @@ metadata:
   - OVNNorthd
   name: ovnnorthd-sample
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-ovn-northd:current-podified
   logLevel: info
   replicas: 1
 status:
@@ -35,7 +34,6 @@ metadata:
   - OVNDBCluster
   name: ovndbcluster-nb-sample
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-ovn-nb-db-server:current-podified
   dbType: NB
   logLevel: info
   replicas: 1
@@ -51,7 +49,6 @@ metadata:
   - OVNDBCluster
   name: ovndbcluster-sb-sample
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-ovn-sb-db-server:current-podified
   dbType: SB
   logLevel: info
   replicas: 1
@@ -71,8 +68,6 @@ spec:
     ovn-bridge: br-int
     ovn-encap-type: geneve
     system-id: random
-  ovnContainerImage: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
-  ovsContainerImage: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
 status:
   conditions:
   - message: Setup complete
@@ -137,7 +132,6 @@ spec:
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
         - /bin/bash
-        image: quay.io/podified-antelope-centos9/openstack-ovn-northd:current-podified
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -301,6 +295,38 @@ commands:
         if [ "$num_nodes" != "$num_pods" ]; then
           echo "Cluster has $num_nodes nodes but OVNController spawned $num_pods pods"
           exit 1
-        else
-          exit 0
         fi
+
+        tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
+        imageTuples=$(oc get -n openstack-operators deployment ovn-operator-controller-manager -o go-template="$tupleTemplate")
+        for ITEM in $(echo $imageTuples); do
+          # it is an image
+          if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+            NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_OVN_\(.*\)_IMAGE.*|\1|')
+            IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
+            template='{{.spec.containerImage}}'
+            case $NAME in
+              NB_DBCLUSTER)
+                SERVICE_IMAGE=$(oc get -n $NAMESPACE ovndbcluster ovndbcluster-nb-sample -o go-template="$template")
+                ;;
+              SB_DBCLUSTER)
+                SERVICE_IMAGE=$(oc get -n $NAMESPACE ovndbcluster ovndbcluster-sb-sample -o go-template="$template")
+                ;;
+              NORTHD)
+                SERVICE_IMAGE=$(oc get -n $NAMESPACE ovnnorthd ovnnorthd-sample -o go-template="$template")
+                ;;
+              CONTROLLER)
+                SERVICE_IMAGE=$(oc get -n $NAMESPACE ovncontroller ovncontroller-sample -o go-template="{{.spec.ovnContainerImage}}")
+                ;;
+              CONTROLLER_OVS)
+                SERVICE_IMAGE=$(oc get -n $NAMESPACE ovncontroller ovncontroller-sample -o go-template="{{.spec.ovsContainerImage}}")
+                ;;
+            esac
+            if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
+                    echo "$NAME image ($SERVICE_IMAGE) does not equal $IMG_FROM_ENV"
+              exit 1
+            fi
+          fi
+        done
+
+        exit 0


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure registry)