### PR TITLE
Change getOvsPodsNodes to getOVNControllerPodsNodes

### DIFF
--- a/pkg/ovncontroller/configjob.go
+++ b/pkg/ovncontroller/configjob.go
@@ -43,7 +43,7 @@ func ConfigJob(
 	// configuration job automatically right after it will be finished
 	jobTTLAfterFinished := int32(0)
 
-	ovsNodes, err := getOvsPodsNodes(
+	ovsNodes, err := getOVNControllerPodsNodes(
 		ctx,
 		k8sClient,
 		instance,

--- a/pkg/ovncontroller/utils.go
+++ b/pkg/ovncontroller/utils.go
@@ -36,7 +36,7 @@ func getPhysicalNetworks(
 	)
 }
 
-func getOvsPodsNodes(
+func getOVNControllerPodsNodes(
 	ctx context.Context,
 	k8sClient client.Client,
 	instance *v1beta1.OVNController,

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -232,7 +232,7 @@ func SimulateDaemonsetNumberReadyWithPods(name types.NamespacedName, networkIPs 
 			"service": "ovn-controller",
 		}
 
-		// NodeName required for getOvsPodsNodes
+		// NodeName required for getOVNControllerPodsNodes
 		pod.Spec.NodeName = name.Name
 
 		var netStatus []networkv1.NetworkStatus


### PR DESCRIPTION
This function came initially from ovs-operator, therefore its old name. Now that it is in ovn-operator and it gets the ovn-controller pods, this name is more appropiate.