### PR TITLE
Ensure bridge and mappings removed with NicMappings cleanup

### DIFF
--- a/templates/ovncontroller/bin/functions
+++ b/templates/ovncontroller/bin/functions
@@ -44,6 +44,8 @@ function configure_external_ids {
     fi
     if [ "$EnableChassisAsGateway" == "true" ]; then
         ovs-vsctl set open . external-ids:ovn-cms-options=enable-chassis-as-gw
+    else
+        ovs-vsctl --if-exists remove open . external_ids ovn-cms-options
     fi
 }
 
@@ -63,5 +65,18 @@ function configure_physical_networks {
     done
     if [ -n "$OvnBridgeMappings" ]; then
         ovs-vsctl set open . external-ids:ovn-bridge-mappings=${OvnBridgeMappings}
+    else
+        # If NicMappings not defined or cleared, let's ensure bridge and bridge-mappings are removed
+        ovn_bms=$(ovs-vsctl --if-exists get open . external_ids:ovn-bridge-mappings|tr -d '"')
+        for bm in ${ovn_bms/,/ }; do
+            ovs-vsctl --if-exists del-br ${bm##*:}
+        done
+        ovs-vsctl --if-exists remove open . external_ids ovn-bridge-mappings
+
+        # If NicMappings not defined or cleared, let's ensure patch ports are removed
+        patch_ports=$(ovs-vsctl --columns=name --bare find interface type=patch)
+        for port in ${patch_ports}; do
+            ovs-vsctl --if-exists del-port br-int $port
+        done
     fi
 }


### PR DESCRIPTION
The bridges and mappings are not cleaned up when NicMappings are dropped from the CR.

Also remove ovn-cms-options when ExternalIDS.EnableChassisAsGateway is reset to false.