### PR TITLE
Add empty spec key for ovncontroller sample

### DIFF
--- a/config/samples/ovn_v1beta1_ovncontroller.yaml
+++ b/config/samples/ovn_v1beta1_ovncontroller.yaml
@@ -2,3 +2,5 @@ apiVersion: ovn.openstack.org/v1beta1
 kind: OVNController
 metadata:
   name: ovncontroller-sample
+# Empty spec key required for kustomization
+spec: {}


### PR DESCRIPTION
make ovn_deploy fails since [1] as oc kustomize
fails with missing path.
This patch adds empty spec key to get it working,
alternative would be to update install_yamls to
create kustomization.yaml specific to ovn.

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/64