### PR TITLE
Create External CM only when DBClusters have NetworkAttachment

### DIFF
--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -197,7 +197,7 @@ func (instance OVNDBCluster) GetInternalEndpoint() (string, error) {
 }
 
 func (instance OVNDBCluster) GetExternalEndpoint() (string, error) {
-	if instance.Status.DBAddress == "" {
+	if instance.Spec.NetworkAttachment != "" && instance.Status.DBAddress == "" {
 		return "", fmt.Errorf("external DBEndpoint not ready yet for %s", instance.Spec.DBType)
 	}
 	return instance.Status.DBAddress, nil

--- a/tests/functional/ovnnorthd_controller_test.go
+++ b/tests/functional/ovnnorthd_controller_test.go
@@ -71,7 +71,7 @@ var _ = Describe("OVNNorthd controller", func() {
 
 		When("OVNDBCluster instances are available", func() {
 			It("should create a Deployment with the ovn connection CLI args set based on the OVNDBCluster", func() {
-				dbs := CreateOVNDBClusters(namespace)
+				dbs := CreateOVNDBClusters(namespace, "")
 				DeferCleanup(DeleteOVNDBClusters, dbs)
 
 				deplName := types.NamespacedName{
@@ -91,7 +91,7 @@ var _ = Describe("OVNNorthd controller", func() {
 
 	When("A OVNNorthd instance is created with debug on", func() {
 		BeforeEach(func() {
-			dbs := CreateOVNDBClusters(namespace)
+			dbs := CreateOVNDBClusters(namespace, "")
 			DeferCleanup(DeleteOVNDBClusters, dbs)
 			name := fmt.Sprintf("ovnnorthd-%s", uuid.New().String())
 			spec := GetDefaultOVNNorthdSpec()
@@ -121,7 +121,7 @@ var _ = Describe("OVNNorthd controller", func() {
 	When("OVNNorthd is created with networkAttachments", func() {
 		var OVNNorthdName types.NamespacedName
 		BeforeEach(func() {
-			dbs := CreateOVNDBClusters(namespace)
+			dbs := CreateOVNDBClusters(namespace, "")
 			DeferCleanup(DeleteOVNDBClusters, dbs)
 			name := fmt.Sprintf("ovnnorthd-%s", uuid.New().String())
 			spec := GetDefaultOVNNorthdSpec()


### PR DESCRIPTION
DBAddress is only set when DBClusters are created with a NetworkAttachment. Same condition is now honored while create External Config Map.

This also fixes the case where ovn-configuration job was not created when DBClusters have no NetworkAttachment.