### PR TITLE
Do not rely on NodeName for ovn-config job

### DIFF
--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -463,7 +463,6 @@ func (r *OVNControllerReconciler) reconcileNormal(ctx context.Context, instance 
 			Log.Error(cleanupConfigMapErr, "Failed to delete external ConfigMap")
 			return ctrl.Result{}, cleanupConfigMapErr
 		}
-		return ctrl.Result{}, nil
 	}
 
 	if sbCluster.Spec.NetworkAttachment != "" {

--- a/pkg/ovncontroller/utils.go
+++ b/pkg/ovncontroller/utils.go
@@ -36,13 +36,12 @@ func getPhysicalNetworks(
 	)
 }
 
-func getOVNControllerPodsNodes(
+func getOVNControllerPods(
 	ctx context.Context,
 	k8sClient client.Client,
 	instance *v1beta1.OVNController,
-) ([]string, error) {
+) (*corev1.PodList, error) {
 
-	var nodes []string
 	podList := &corev1.PodList{}
 	podListOpts := &client.ListOptions{
 		Namespace: instance.Namespace,
@@ -53,14 +52,10 @@ func getOVNControllerPodsNodes(
 
 	if err := k8sClient.List(ctx, podList, podListOpts); err != nil {
 		err = fmt.Errorf("error listing pods for instance %s: %w", instance.Name, err)
-		return []string{}, err
+		return podList, err
 	}
 
-	for _, pod := range podList.Items {
-		nodes = append(nodes, pod.Spec.NodeName)
-	}
-
-	return nodes, nil
+	return podList, nil
 }
 
 // EnvDownwardAPI - set env from FieldRef->FieldPath, e.g. status.podIP

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -228,12 +228,12 @@ func SimulateDaemonsetNumberReadyWithPods(name types.NamespacedName, networkIPs 
 			Spec:       ds.Spec.Template.Spec,
 		}
 		pod.ObjectMeta.Namespace = name.Namespace
-		pod.ObjectMeta.GenerateName = name.Name
+		pod.ObjectMeta.Name = name.Name
 		pod.ObjectMeta.Labels = map[string]string{
 			"service": "ovn-controller",
 		}
 
-		// NodeName required for getOVNControllerPodsNodes
+		// NodeName required for getOVNControllerPods
 		pod.Spec.NodeName = name.Name
 
 		var netStatus []networkv1.NetworkStatus


### PR DESCRIPTION
There is a max limit of 63 characters on the job name,
and using Instance Name + NodeName(with fqdn) can surpass
this limit and cause config jobs to not be created.

Instead switch the job names to rely on ovn-controller
pod names which will already be unique and size
length is constant as pod names are based on daemonset Name.

Also when External Endpoint is not set[1] we don't need
to return as it will never be set when DBClusters are running
without NetworkAttachment. For NetworkAttachment case it's
already taken care as part of generateExternalConfigMaps.

Added functional tests for the same.

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/153
Resolves: https://issues.redhat.com/browse/OSPRH-683