### PR TITLE
Include status.networkAttachments in PrinterColumns

### DIFF
--- a/api/bases/ovn.openstack.org_ovncontrollers.yaml
+++ b/api/bases/ovn.openstack.org_ovncontrollers.yaml
@@ -16,9 +16,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: NetworkAttachment
-      jsonPath: .spec.networkAttachment
-      name: NetworkAttachment
+    - description: NetworkAttachments
+      jsonPath: .status.networkAttachments
+      name: NetworkAttachments
       type: string
     - description: Status
       jsonPath: .status.conditions[0].status

--- a/api/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/api/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: NetworkAttachments
-      jsonPath: .spec.networkAttachments
+      jsonPath: .status.networkAttachments
       name: NetworkAttachments
       type: string
     - description: Status

--- a/api/bases/ovn.openstack.org_ovnnorthds.yaml
+++ b/api/bases/ovn.openstack.org_ovnnorthds.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: NetworkAttachments
-      jsonPath: .spec.networkAttachments
+      jsonPath: .status.networkAttachments
       name: NetworkAttachments
       type: string
     - description: Status

--- a/api/v1beta1/ovncontroller_types.go
+++ b/api/v1beta1/ovncontroller_types.go
@@ -101,7 +101,7 @@ type OVNControllerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="NetworkAttachment",type="string",JSONPath=".spec.networkAttachment",description="NetworkAttachment"
+//+kubebuilder:printcolumn:name="NetworkAttachments",type="string",JSONPath=".status.networkAttachments",description="NetworkAttachments"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -141,7 +141,7 @@ type OVNDBClusterStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="NetworkAttachments",type="string",JSONPath=".spec.networkAttachments",description="NetworkAttachments"
+//+kubebuilder:printcolumn:name="NetworkAttachments",type="string",JSONPath=".status.networkAttachments",description="NetworkAttachments"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 

--- a/api/v1beta1/ovnnorthd_types.go
+++ b/api/v1beta1/ovnnorthd_types.go
@@ -90,7 +90,7 @@ type OVNNorthdStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="NetworkAttachments",type="string",JSONPath=".spec.networkAttachments",description="NetworkAttachments"
+//+kubebuilder:printcolumn:name="NetworkAttachments",type="string",JSONPath=".status.networkAttachments",description="NetworkAttachments"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 

--- a/config/crd/bases/ovn.openstack.org_ovncontrollers.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovncontrollers.yaml
@@ -16,9 +16,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: NetworkAttachment
-      jsonPath: .spec.networkAttachment
-      name: NetworkAttachment
+    - description: NetworkAttachments
+      jsonPath: .status.networkAttachments
+      name: NetworkAttachments
       type: string
     - description: Status
       jsonPath: .status.conditions[0].status

--- a/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: NetworkAttachments
-      jsonPath: .spec.networkAttachments
+      jsonPath: .status.networkAttachments
       name: NetworkAttachments
       type: string
     - description: Status

--- a/config/crd/bases/ovn.openstack.org_ovnnorthds.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovnnorthds.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: NetworkAttachments
-      jsonPath: .spec.networkAttachments
+      jsonPath: .status.networkAttachments
       name: NetworkAttachments
       type: string
     - description: Status


### PR DESCRIPTION
Printing the status.networkAttachments instead of the spec part is more useful as it dumps pod IPs.