### PR TITLE
Use dumb-init for ovndb/ovncontroller pods

### DIFF
--- a/pkg/ovndbcluster/statefulset.go
+++ b/pkg/ovndbcluster/statefulset.go
@@ -60,7 +60,8 @@ func StatefulSet(
 	}
 	var preStopCmd []string
 	var postStartCmd []string
-	args := []string{"-c"}
+	cmd := []string{"/usr/bin/dumb-init"}
+	args := []string{"--single-child", "--", "/bin/bash", "-c"}
 	if instance.Spec.Debug.Service {
 		args = append(args, common.DebugCommand)
 		livenessProbe.Exec = &corev1.ExecAction{
@@ -135,12 +136,10 @@ func StatefulSet(
 					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
-							Name: serviceName,
-							Command: []string{
-								"/bin/bash",
-							},
-							Args:  args,
-							Image: instance.Spec.ContainerImage,
+							Name:    serviceName,
+							Command: cmd,
+							Args:    args,
+							Image:   instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,
 							},

--- a/tests/functional/ovndbcluster_controller_test.go
+++ b/tests/functional/ovndbcluster_controller_test.go
@@ -127,7 +127,7 @@ var _ = Describe("OVNDBCluster controller", func() {
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(ss.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command).To(
 				Equal([]string{"/bin/true"}))
-			Expect(ss.Spec.Template.Spec.Containers[0].Args[1]).Should(ContainSubstring("sleep infinity"))
+			Expect(ss.Spec.Template.Spec.Containers[0].Args[4]).Should(ContainSubstring("sleep infinity"))
 			Expect(ss.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec.Command).To(
 				Equal([]string{"/bin/true"}))
 			Expect(ss.Spec.Template.Spec.Containers[0].Lifecycle.PostStart.Exec.Command).To(


### PR DESCRIPTION
In these pods we are using bash scripts as entrypoint and with these SIGTERM signals are not forwarded to child processes, Use dumb-init to handle graceful shutdown of these child processes.

Also for PreStop add a sleep to workaround
the issue https://github.com/kubernetes/kubernetes/issues/39170

Resolves: https://issues.redhat.com/browse/OSPRH-770