### PR TITLE
Run ovn ovsdb-servers as anyuid

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -222,6 +222,14 @@ rules:
   - security.openshift.io
   resourceNames:
   - anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
   - privileged
   resources:
   - securitycontextconstraints

--- a/controllers/ovndbcluster_controller.go
+++ b/controllers/ovndbcluster_controller.go
@@ -91,7 +91,7 @@ func (r *OVNDBClusterReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update
 // service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile - OVN DBCluster
@@ -254,7 +254,7 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid", "privileged"},
+			ResourceNames: []string{"anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},
@@ -617,15 +617,6 @@ func (r *OVNDBClusterReconciler) generateServiceConfigMaps(
 			Name:          fmt.Sprintf("%s-scripts", instance.Name),
 			Namespace:     instance.Namespace,
 			Type:          util.TemplateTypeScripts,
-			InstanceType:  instance.Kind,
-			Labels:        cmLabels,
-			ConfigOptions: templateParameters,
-		},
-		// ConfigMap
-		{
-			Name:          fmt.Sprintf("%s-config-data", instance.Name),
-			Namespace:     instance.Namespace,
-			Type:          util.TemplateTypeConfig,
 			InstanceType:  instance.Kind,
 			Labels:        cmLabels,
 			ConfigOptions: templateParameters,

--- a/pkg/ovndbcluster/volumes.go
+++ b/pkg/ovndbcluster/volumes.go
@@ -6,26 +6,9 @@ import corev1 "k8s.io/api/core/v1"
 // TODO: merge to GetVolumes when other controllers also switched to current config
 // mechanism.
 func GetDBClusterVolumes(name string) []corev1.Volume {
-	var config0640AccessMode int32 = 0640
 	var scriptsVolumeDefaultMode int32 = 0755
 
 	return []corev1.Volume{
-		{
-			Name: "etc-machine-id",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/machine-id",
-				},
-			},
-		},
-		{
-			Name: "etc-localtime",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/localtime",
-				},
-			},
-		},
 		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
@@ -33,17 +16,6 @@ func GetDBClusterVolumes(name string) []corev1.Volume {
 					DefaultMode: &scriptsVolumeDefaultMode,
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: name + "-scripts",
-					},
-				},
-			},
-		},
-		{
-			Name: "config-data",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
 					},
 				},
 			},
@@ -56,29 +28,8 @@ func GetDBClusterVolumes(name string) []corev1.Volume {
 func GetDBClusterVolumeMounts(name string) []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
-			Name:      "etc-machine-id",
-			MountPath: "/etc/machine-id",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "etc-localtime",
-			MountPath: "/etc/localtime",
-			ReadOnly:  true,
-		},
-		{
 			Name:      "scripts",
 			MountPath: "/usr/local/bin/container-scripts",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "config-data",
-			MountPath: "/var/lib/config-data",
-			ReadOnly:  false,
-		},
-		{
-			Name:      "config-data",
-			MountPath: "/var/lib/kolla/config_files/config.json",
-			SubPath:   "ovn-dbcluster.json",
 			ReadOnly:  true,
 		},
 		{

--- a/templates/ovndbcluster/config/ovn-dbcluster.json
+++ b/templates/ovndbcluster/config/ovn-dbcluster.json
@@ -1,3 +1,0 @@
-{
-  "command": "/usr/local/bin/container-scripts/setup.sh"
-}

--- a/tests/functional/ovndbcluster_controller_test.go
+++ b/tests/functional/ovndbcluster_controller_test.go
@@ -72,10 +72,9 @@ var _ = Describe("OVNDBCluster controller", func() {
 				}
 				th.AssertConfigMapDoesNotExist(cm)
 			},
-			Entry("config-data CM", "config-data"),
 			Entry("scripts CM", "scripts"),
 		)
-		DescribeTable("should eventually create the config maps with OwnerReferences set",
+		DescribeTable("should eventually create the config map with OwnerReferences set",
 			func(cmName string) {
 				cm := types.NamespacedName{
 					Namespace: OVNDBClusterName.Namespace,
@@ -89,7 +88,6 @@ var _ = Describe("OVNDBCluster controller", func() {
 				Expect(th.GetConfigMap(cm).ObjectMeta.OwnerReferences[0].Name).To(Equal(OVNDBClusterName.Name))
 				Expect(th.GetConfigMap(cm).ObjectMeta.OwnerReferences[0].Kind).To(Equal("OVNDBCluster"))
 			},
-			Entry("config-data CM", "config-data"),
 			Entry("scripts CM", "scripts"),
 		)
 

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -182,7 +182,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: privileged
+    openshift.io/scc: anyuid
   labels:
     service: ovsdbserver-nb
   name: ovsdbserver-nb-0
@@ -191,7 +191,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    openshift.io/scc: privileged
+    openshift.io/scc: anyuid
   labels:
     service: ovsdbserver-sb
   name: ovsdbserver-sb-0


### PR DESCRIPTION
We may explore tightening it further to restricted-v2 later.

The change gets rid of kolla in startup path in line with:

https://github.com/openstack-k8s-operators/docs/pull/77