### PR TITLE
Deescalate ovn-controller to hostmount-anyuid

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -229,8 +229,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - anyuid
-  - privileged
+  - hostmount-anyuid
   resources:
   - securitycontextconstraints
   verbs:

--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -103,7 +103,7 @@ func (r *OVNControllerReconciler) GetClient() client.Client {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update
 // service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=hostmount-anyuid,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 
 func (r *OVNControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -270,7 +270,7 @@ func (r *OVNControllerReconciler) reconcileNormal(ctx context.Context, instance 
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid", "privileged"},
+			ResourceNames: []string{"hostmount-anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},

--- a/pkg/ovncontroller/daemonset.go
+++ b/pkg/ovncontroller/daemonset.go
@@ -30,9 +30,6 @@ func DaemonSet(
 	annotations map[string]string,
 ) (*appsv1.DaemonSet, error) {
 
-	runAsUser := int64(0)
-	privileged := true
-
 	//
 	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 	//
@@ -163,15 +160,7 @@ func DaemonSet(
 									},
 								},
 							},
-							Image: instance.Spec.OvsContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								Capabilities: &corev1.Capabilities{
-									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN"},
-									Drop: []corev1.Capability{},
-								},
-								RunAsUser:  &runAsUser,
-								Privileged: &privileged,
-							},
+							Image:                    instance.Spec.OvsContainerImage,
 							Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:             GetOvsDbVolumeMounts(),
 							Resources:                instance.Spec.Resources,
@@ -189,15 +178,7 @@ func DaemonSet(
 									},
 								},
 							},
-							Image: instance.Spec.OvsContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								Capabilities: &corev1.Capabilities{
-									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN"},
-									Drop: []corev1.Capability{},
-								},
-								RunAsUser:  &runAsUser,
-								Privileged: &privileged,
-							},
+							Image:                    instance.Spec.OvsContainerImage,
 							Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:             GetVswitchdVolumeMounts(),
 							Resources:                instance.Spec.Resources,
@@ -219,16 +200,7 @@ func DaemonSet(
 									},
 								},
 							},
-							Image: instance.Spec.OvnContainerImage,
-							// TODO(slaweq): to check if ovn-controller really needs such security contexts
-							SecurityContext: &corev1.SecurityContext{
-								Capabilities: &corev1.Capabilities{
-									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN"},
-									Drop: []corev1.Capability{},
-								},
-								RunAsUser:  &runAsUser,
-								Privileged: &privileged,
-							},
+							Image:                    instance.Spec.OvnContainerImage,
 							Env:                      env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:             GetOvnControllerVolumeMounts(),
 							Resources:                instance.Spec.Resources,

--- a/pkg/ovncontroller/daemonset.go
+++ b/pkg/ovncontroller/daemonset.go
@@ -166,7 +166,7 @@ func DaemonSet(
 							Image: instance.Spec.OvsContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"},
+									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN"},
 									Drop: []corev1.Capability{},
 								},
 								RunAsUser:  &runAsUser,
@@ -192,7 +192,7 @@ func DaemonSet(
 							Image: instance.Spec.OvsContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"},
+									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN"},
 									Drop: []corev1.Capability{},
 								},
 								RunAsUser:  &runAsUser,
@@ -223,7 +223,7 @@ func DaemonSet(
 							// TODO(slaweq): to check if ovn-controller really needs such security contexts
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"},
+									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN"},
 									Drop: []corev1.Capability{},
 								},
 								RunAsUser:  &runAsUser,


### PR DESCRIPTION
This is not ready - need to understand how to overcome selinux violations that stop the pods from seeing into hostPath mounts from /home.

TODO: update to anyuid once the last hostMount is gone.