### PR TITLE
Add tempest job in check pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ PROC_CMD = --procs ${PROCS}
 
 .PHONY: test
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" OPERATOR_TEMPLATES="$(PWD)/templates" $(GINKGO) --trace --cover --coverpkg=../../pkg/ovndbcluster,../../pkg/ovnnorthd,../../pkg/ovncontroller,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./tests/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" OPERATOR_TEMPLATES="$(shell pwd)/templates" $(GINKGO) --trace --cover --coverpkg=../../pkg/ovndbcluster,../../pkg/ovnnorthd,../../pkg/ovncontroller,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./tests/...
 
 ##@ Build
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,0 +1,8 @@
+---
+- job:
+    name: ovn-operator-tempest-multinode
+    parent: neutron-operator-tempest-multinode
+    dependencies: ["openstack-k8s-operators-content-provider"]
+    vars:
+      cifmw_tempest_tests_allowed:
+        - neutron_tempest_plugin.scenario

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -1,0 +1,7 @@
+---
+- project:
+    name: openstack-k8s-operators/ovn-operator
+    github-check:
+      jobs:
+        - openstack-k8s-operators-content-provider
+        - ovn-operator-tempest-multinode


### PR DESCRIPTION
The job runs neutron tempest plugin scenario tests.

Depends-On: https://github.com/openstack-k8s-operators/neutron-operator/pull/278
Resolves: [OSPRH-678](https://issues.redhat.com//browse/OSPRH-678)