### PR TITLE
Add type label into headless/normal services

### DIFF
--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -31,6 +31,11 @@ const (
 	// SBDBType - Southbound database type
 	SBDBType = "SB"
 
+	// ServiceHeadlessType - Constant to identify Headless services
+	ServiceHeadlessType = "headless"
+	// ServiceClusterType - Constant to identify Cluster services
+	ServiceClusterType = "cluster"
+
 	// DNSSuffix : hardcoded value on how DNSCore domain is configured
 	DNSSuffix = "cluster.local"
 	// TODO: retrieve it from environment

--- a/pkg/ovndbcluster/service.go
+++ b/pkg/ovndbcluster/service.go
@@ -12,6 +12,7 @@ func Service(
 	serviceName string,
 	instance *ovnv1.OVNDBCluster,
 	serviceLabels map[string]string,
+	selectorLabels map[string]string,
 ) *corev1.Service {
 	dbPortName := "north"
 	raftPortName := "north-raft"
@@ -30,7 +31,7 @@ func Service(
 			Labels:    serviceLabels,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: serviceLabels,
+			Selector: selectorLabels,
 			Ports: []corev1.ServicePort{
 				{
 					Name:     dbPortName,
@@ -52,6 +53,7 @@ func HeadlessService(
 	serviceName string,
 	instance *ovnv1.OVNDBCluster,
 	serviceLabels map[string]string,
+	selectorLabels map[string]string,
 ) *corev1.Service {
 	raftPortName := "north-raft"
 	var raftPort int32 = 6643
@@ -66,7 +68,7 @@ func HeadlessService(
 			Labels:    serviceLabels,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: serviceLabels,
+			Selector: selectorLabels,
 			Ports: []corev1.ServicePort{
 				{
 					Name:     raftPortName,

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -307,3 +307,25 @@ func GetPod(name types.NamespacedName) *corev1.Pod {
 func UpdatePod(pod *corev1.Pod) {
 	k8sClient.Update(ctx, pod)
 }
+
+func GetServicesListWithLabel(namespace string, labelSelectorMap ...map[string]string) *corev1.ServiceList {
+	serviceList := &corev1.ServiceList{}
+	serviceListOpts := client.ListOptions{
+		Namespace: namespace,
+	}
+	if len(labelSelectorMap) > 0 {
+		for i := 0; i < len(labelSelectorMap); i++ {
+			for key, value := range labelSelectorMap[i] {
+				ml := client.MatchingLabels{
+					key: value,
+				}
+				ml.ApplyToList(&serviceListOpts)
+			}
+		}
+	}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.List(ctx, serviceList, &serviceListOpts)).Should(Succeed())
+	}).Should(Succeed())
+
+	return serviceList
+}


### PR DESCRIPTION
Adding type label to easier search between headless or normal service and use them to filter only the normal services during scale-down service removal.

Resolves: [OSPRH-4120](https://issues.redhat.com//browse/OSPRH-4120)