### PR TITLE
[ovn-northd] Don't set DeployReady condition with replicas 0

### DIFF
--- a/controllers/ovnnorthd_controller.go
+++ b/controllers/ovnnorthd_controller.go
@@ -370,6 +370,8 @@ func (r *OVNNorthdReconciler) reconcileNormal(ctx context.Context, instance *ovn
 
 	if instance.Status.ReadyCount > 0 {
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+	} else if *instance.Spec.Replicas == 0 {
+		instance.Status.Conditions.Remove(condition.DeploymentReadyCondition)
 	}
 	// create Deployment - end
 


### PR DESCRIPTION
When OVNNorthd CR is created with 0 replicas, deployment
get's created and DeploymentReady condition was not set which
leads to Northd CR not getting to Ready State.

With this patch, when northd is deployed with 0 replicas
we drop DeploymentReady condition and let Ready condition
get's set for it.

Related-Issue: [OSPRH-2437](https://issues.redhat.com//browse/OSPRH-2437)