### PR TITLE
Add octavia mapping if present (example)

### DIFF
--- a/templates/ovncontroller/bin/functions
+++ b/templates/ovncontroller/bin/functions
@@ -59,6 +59,13 @@ function configure_external_ids {
 
 # Configure bridge mappings and physical bridges
 function configure_physical_networks {
+
+    set +ex
+
+    # Add br-octavia if octavia is being deployed.
+    (ip -br link show octavia > /dev/null 2>&1) && PhysicalNetworks="octavia $PhysicalNetworks"
+
+    set -ex
     local OvnBridgeMappings=""
     for physicalNetwork in ${PhysicalNetworks}; do
         br_name="br-${physicalNetwork}"


### PR DESCRIPTION
A workaround for adding the octavia attachment as a bridge mapping if present.

(Sample patch that illustrates an intrustive yet basic approach)