### PR TITLE
Handle the physical network changes "ovn-bridge-mappings"

### DIFF
--- a/config/samples/nad_datacentre2.yaml
+++ b/config/samples/nad_datacentre2.yaml
@@ -1,0 +1,17 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  annotations:
+  labels:
+    osp/net: datacentre2
+    service: ovn-controller
+  name: datacentre2
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "datacentre2",
+      "type": "bridge",
+      "bridge": "ospbr2",
+      "ipam": {}
+    }

--- a/config/samples/nad_datacentre3.yaml
+++ b/config/samples/nad_datacentre3.yaml
@@ -1,0 +1,17 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  annotations:
+  labels:
+    osp/net: datacentre3
+    service: ovn-controller
+  name: datacentre3
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "datacentre3",
+      "type": "bridge",
+      "bridge": "ospbr3",
+      "ipam": {}
+    }

--- a/templates/ovncontroller/bin/functions
+++ b/templates/ovncontroller/bin/functions
@@ -57,34 +57,76 @@ function configure_external_ids {
     fi
 }
 
+# Returns the set difference between $1 and $2
+function set_difference {
+    echo "$(comm -23 <(sort <(echo $1 | xargs -n1)) <(sort <(echo $2 | xargs -n1)))"
+}
+
 # Configure bridge mappings and physical bridges
 function configure_physical_networks {
     local OvnBridgeMappings=""
+    local br_new=""
     for physicalNetwork in ${PhysicalNetworks}; do
         br_name="br-${physicalNetwork}"
-        ovs-vsctl --may-exist add-br ${br_name}
-        ovs-vsctl --may-exist add-port ${br_name} ${physicalNetwork}
         bridgeMapping="${physicalNetwork}:${br_name}"
         if [ -z "$OvnBridgeMappings"]; then
             OvnBridgeMappings=$bridgeMapping
+            br_new=$br_name
         else
             OvnBridgeMappings="${OvnBridgeMappings},${bridgeMapping}"
+            br_new="${br_new} ${br_name}"
         fi
     done
+
+    # Current configured bridges.
+    ovn_bms=$(ovs-vsctl --if-exists get open . external_ids:ovn-bridge-mappings|tr -d '"')
+    local br_current=""
+    for bm in ${ovn_bms/,/ }; do
+        if [ -z "$br_current"]; then
+            br_current=${bm##*:}
+        else
+            br_current="${br_current} ${bm##*:}"
+        fi
+    done
+
+    # Bridges to add and delete.
+    local br_to_delete=""
+    local br_to_add=""
+    br_to_delete=$(set_difference "$br_current" "$br_new")
+    br_to_add=$(set_difference "$br_new" "$br_current")
+
+    # Add the new bridges.
+    for br_name in ${br_to_add}; do
+        ovs-vsctl --may-exist add-br ${br_name}
+        ovs-vsctl --may-exist add-port ${br_name} ${br_name##*-}
+    done
+
+    # Delete the old bridges not longer present in "OvnBridgeMappings" and the
+    # patch ports in "br-int".
+    for br_name in ${br_to_delete}; do
+        # List all ports "type=patch", retrieve the "options:peer" parameter
+        # and delete the peer port. The "$port" will be deleted during the
+        # bridge deletion.
+        #   $ ovs-vsctl --column=options --bare find interface name=patch-provnet1-to-br-int type=patch
+        #     peer=patch-br-int-to-provnet1
+
+        if ovs-vsctl br-exists ${br_name}; then
+            for iface in $(ovs-vsctl list-ifaces ${br_name}); do
+                port_type=$(ovs-vsctl --column=type --bare list interface ${iface})
+                if [ "$port_type" == "patch" ]; then
+                    peer=$(ovs-vsctl get interface ${iface} options:peer)
+                    ovs-vsctl --if-exists del-port ${OvnBridge} ${peer}
+                fi
+            done
+            ovs-vsctl --if-exists del-br ${br_name}
+        fi
+    done
+
+    # Set or remove the local OVS Open vSwitch "external-ids:ovn-bridge-mappings"
     if [ -n "$OvnBridgeMappings" ]; then
         ovs-vsctl set open . external-ids:ovn-bridge-mappings=${OvnBridgeMappings}
     else
-        # If NicMappings not defined or cleared, let's ensure bridge and bridge-mappings are removed
-        ovn_bms=$(ovs-vsctl --if-exists get open . external_ids:ovn-bridge-mappings|tr -d '"')
-        for bm in ${ovn_bms/,/ }; do
-            ovs-vsctl --if-exists del-br ${bm##*:}
-        done
         ovs-vsctl --if-exists remove open . external_ids ovn-bridge-mappings
-
-        # If NicMappings not defined or cleared, let's ensure patch ports are removed
-        patch_ports=$(ovs-vsctl --columns=name --bare find interface type=patch)
-        for port in ${patch_ports}; do
-            ovs-vsctl --if-exists del-port br-int $port
-        done
     fi
+
 }

--- a/tests/kuttl/common/cleanup-ovn.yaml
+++ b/tests/kuttl/common/cleanup-ovn.yaml
@@ -13,3 +13,9 @@ delete:
 - apiVersion: ovn.openstack.org/v1beta1
   kind: OVNController
   name: ovncontroller-sample
+- apiVersion: k8s.cni.cncf.io/v1
+  kind: NetworkAttachmentDefinition
+  name: datacentre2
+- apiVersion: k8s.cni.cncf.io/v1
+  kind: NetworkAttachmentDefinition
+  name: datacentre3

--- a/tests/kuttl/tests/ovn_nicmappings/01-assert.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/01-assert.yaml
@@ -1,0 +1,1 @@
+../../common/assert_sample_deployment.yaml

--- a/tests/kuttl/tests/ovn_nicmappings/01-deploy-ovn.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/01-deploy-ovn.yaml
@@ -1,0 +1,1 @@
+../../common/deploy_ovn.yaml

--- a/tests/kuttl/tests/ovn_nicmappings/02-new-network-attachment-definition.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/02-new-network-attachment-definition.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc apply -n $NAMESPACE -f ../../../../config/samples/nad_datacentre2.yaml
+      oc apply -n $NAMESPACE -f ../../../../config/samples/nad_datacentre3.yaml

--- a/tests/kuttl/tests/ovn_nicmappings/03-assert.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/03-assert.yaml
@@ -1,0 +1,18 @@
+#
+# Check for:
+#
+# - The interface "datacentre2" exists in the ovn-controller container
+# - The OVS Open vSwitch external_ids:ovn-bridge-mappings is configured correctly
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+commands:
+    - script: |
+        controller_pod=$(oc get pod -n $NAMESPACE -l service=ovn-controller-ovs -o name|head -1)
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev datacentre2 || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-datacentre2 || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev datacentre3 2>&1 | grep "does not exist" || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-datacentre3 2>&1 | grep "does not exist" || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ovs-vsctl --if-exists get open . external_ids:ovn-bridge-mappings | grep -q "datacentre2:br-datacentre2" || exit 1
+        exit 0

--- a/tests/kuttl/tests/ovn_nicmappings/03-nicmappings-patch-datacentre2.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/03-nicmappings-patch-datacentre2.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 60
+commands:
+  - script: |
+      oc patch OVNController -n $NAMESPACE ovncontroller-sample --type='json' -p='[{
+        "op": "replace",
+        "path": "/spec/nicMappings",
+        "value":{"datacentre2":"ospbr2"}
+      }]'

--- a/tests/kuttl/tests/ovn_nicmappings/04-assert.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/04-assert.yaml
@@ -1,0 +1,19 @@
+#
+# Check for:
+#
+# - The interface "datacentre3" exists in the ovn-controller container
+# - The interface "datacentre2" no longer exists in the ovn-controller container
+# - The OVS Open vSwitch external_ids:ovn-bridge-mappings is configured correctly
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+commands:
+    - script: |
+        controller_pod=$(oc get pod -n $NAMESPACE -l service=ovn-controller-ovs -o name|head -1)
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev datacentre3 || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-datacentre3 || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev datacentre2 2>&1 | grep "does not exist" || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-datacentre2 2>&1 | grep "does not exist" || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ovs-vsctl --if-exists get open . external_ids:ovn-bridge-mappings | grep "datacentre2:br-datacentre2" && exit 1
+        exit 0

--- a/tests/kuttl/tests/ovn_nicmappings/04-nicmappings-patch-datacentre3.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/04-nicmappings-patch-datacentre3.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 60
+commands:
+  - script: |
+      oc patch OVNController -n $NAMESPACE ovncontroller-sample --type='json' -p='[{
+        "op": "replace",
+        "path": "/spec/nicMappings",
+        "value":{"datacentre3":"ospbr3"}
+      }]'

--- a/tests/kuttl/tests/ovn_nicmappings/06-cleanup-ovn.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/06-cleanup-ovn.yaml
@@ -1,0 +1,1 @@
+../../common/cleanup-ovn.yaml

--- a/tests/kuttl/tests/ovn_nicmappings/06-errors.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/06-errors.yaml
@@ -1,0 +1,1 @@
+../../common/errors_cleanup_ovn.yaml


### PR DESCRIPTION
Now when the physical network changes, the list of OVS bridges is compared to the current one:
* The new bridges are added to OVS.
* The old bridges are deleted along with the patch port to "br-int".
* The new "ovn-bridge-mappings" is set in the local OVS Open vSwitch register.

Closes: [OSPRH-3124](https://issues.redhat.com//browse/OSPRH-3124)