### PR TITLE
Remove raftAddress from CRD

### DIFF
--- a/api/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/api/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -238,9 +238,6 @@ spec:
                   generation, then the controller has not processed the latest changes.
                 format: int64
                 type: integer
-              raftAddress:
-                description: RaftAddress -
-                type: string
               readyCount:
                 description: ReadyCount of OVN DBCluster instances
                 format: int32

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -135,9 +135,6 @@ type OVNDBClusterStatus struct {
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
-	// RaftAddress -
-	RaftAddress string `json:"raftAddress,omitempty"`
-
 	// DBAddress - DB IP address used by external nodes
 	DBAddress string `json:"dbAddress,omitempty"`
 

--- a/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -238,9 +238,6 @@ spec:
                   generation, then the controller has not processed the latest changes.
                 format: int64
                 type: integer
-              raftAddress:
-                description: RaftAddress -
-                type: string
               readyCount:
                 description: ReadyCount of OVN DBCluster instances
                 format: int32

--- a/controllers/ovndbcluster_controller.go
+++ b/controllers/ovndbcluster_controller.go
@@ -586,7 +586,6 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 		instance.Status.Conditions.MarkTrue(condition.ExposeServiceReadyCondition, condition.ExposeServiceReadyMessage)
 		internalDbAddress := []string{}
-		raftAddress := []string{}
 		var svcPort int32
 		scheme := "tcp"
 		if instance.Spec.TLS.Enabled() {
@@ -598,7 +597,6 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 			// Filter out headless services
 			if svc.Spec.ClusterIP != "None" {
 				internalDbAddress = append(internalDbAddress, fmt.Sprintf("%s:%s.%s.svc.%s:%d", scheme, svc.Name, svc.Namespace, ovnv1.DNSSuffix, svcPort))
-				raftAddress = append(raftAddress, fmt.Sprintf("%s:%s.%s.svc.%s:%d", scheme, svc.Name, svc.Namespace, ovnv1.DNSSuffix, svc.Spec.Ports[1].Port))
 			}
 		}
 
@@ -609,8 +607,6 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 
 		// Set DB Address
 		instance.Status.InternalDBAddress = strings.Join(internalDbAddress, ",")
-		// Set RaftAddress
-		instance.Status.RaftAddress = strings.Join(raftAddress, ",")
 	}
 	Log.Info("Reconciled Service successfully")
 	instance.Status.ObservedGeneration = instance.Generation

--- a/tests/functional/ovndbcluster_controller_test.go
+++ b/tests/functional/ovndbcluster_controller_test.go
@@ -473,7 +473,6 @@ var _ = Describe("OVNDBCluster controller", func() {
 				OVNDBCluster := GetOVNDBCluster(OVNDBClusterName)
 				g.Expect(OVNDBCluster.Status.DBAddress).To(HavePrefix("ssl:"))
 				g.Expect(OVNDBCluster.Status.InternalDBAddress).To(HavePrefix("ssl:"))
-				g.Expect(OVNDBCluster.Status.RaftAddress).To(HavePrefix("ssl:"))
 			}, timeout, interval).Should(Succeed())
 
 			// check scripts configure TLS


### PR DESCRIPTION
It is not used for anything.

Closes: https://issues.redhat.com/browse/OSPRH-3125