### PR TITLE
No-op, build with latest openstack-ovn images

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+


### PR DESCRIPTION
Current ovn-operator references openstack-ovn images from 21 days ago, which are no longer compatible with the new images referenced in the data plane operator. Forcing a rebuild of ovn operator and openstack operator to update the references.