### PR TITLE
Fix ovn_controller tls args

### DIFF
--- a/pkg/ovncontroller/daemonset.go
+++ b/pkg/ovncontroller/daemonset.go
@@ -14,6 +14,7 @@ package ovncontroller
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
@@ -72,7 +73,7 @@ func CreateOVNDaemonSet(
 		{
 			Name:    "ovn-controller",
 			Command: []string{"/bin/bash", "-c"},
-			Args:    args,
+			Args:    []string{strings.Join(args, " ")},
 			Lifecycle: &corev1.Lifecycle{
 				PreStop: &corev1.LifecycleHandler{
 					Exec: &corev1.ExecAction{


### PR DESCRIPTION
TLS support in ovn was originally added with [1], but tls args got messed in [2], the issue got visible after
tls enabled by default[3], this patch fixes it.

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/234
[2] https://github.com/openstack-k8s-operators/ovn-operator/pull/233
[3] https://github.com/openstack-k8s-operators/openstack-operator/pull/727

Related-Issue: [OSPRH-2191](https://issues.redhat.com//browse/OSPRH-2191)
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/745