### PR TITLE
Switch to tempest role for running tempest

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -4,5 +4,6 @@
     parent: neutron-operator-tempest-multinode
     dependencies: ["openstack-k8s-operators-content-provider"]
     vars:
+      cifmw_run_test_role: tempest
       cifmw_tempest_tests_allowed:
         - neutron_tempest_plugin.scenario


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/1391 moves to test_operator role for running tempest tests. It broke the existing vars based on tempest role.
It also needs to be migrated to test_operator.
Let use tempest role here to bring back running tempest tests.