### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,5 +69,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/api/v1beta1/client.go
+++ b/api/v1beta1/client.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -88,8 +88,9 @@ func getItems(list client.ObjectList) []client.Object {
 }
 
 // OVNDBClusterNamespaceMapFunc - DBCluster Watch Function
-func OVNDBClusterNamespaceMapFunc(crs client.ObjectList, reader client.Reader, log logr.Logger) handler.MapFunc {
+func OVNDBClusterNamespaceMapFunc(crs client.ObjectList, reader client.Reader) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		log := log.FromContext(ctx)
 		result := []reconcile.Request{}
 
 		// get all CRs from the same namespace, right now there should only be one

--- a/controllers/ovnnorthd_controller.go
+++ b/controllers/ovnnorthd_controller.go
@@ -188,8 +188,7 @@ func (r *OVNNorthdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OVNNorthdReconciler) SetupWithManager(mgr ctrl.Manager, ctx context.Context) error {
-	Log := r.GetLogger(ctx)
+func (r *OVNNorthdReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	crs := &ovnv1.OVNNorthdList{}
 	// index caBundleSecretNameField
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ovnv1.OVNNorthd{}, caBundleSecretNameField, func(rawObj client.Object) []string {
@@ -221,7 +220,7 @@ func (r *OVNNorthdReconciler) SetupWithManager(mgr ctrl.Manager, ctx context.Con
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
-		Watches(&ovnv1.OVNDBCluster{}, handler.EnqueueRequestsFromMapFunc(ovnv1.OVNDBClusterNamespaceMapFunc(crs, mgr.GetClient(), Log))).
+		Watches(&ovnv1.OVNDBCluster{}, handler.EnqueueRequestsFromMapFunc(ovnv1.OVNDBClusterNamespaceMapFunc(crs, mgr.GetClient()))).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),
@@ -274,7 +273,7 @@ func (r *OVNNorthdReconciler) reconcileDelete(ctx context.Context, instance *ovn
 	return ctrl.Result{}, nil
 }
 
-func (r *OVNNorthdReconciler) reconcileUpdate(ctx context.Context, instance *ovnv1.OVNNorthd, helper *helper.Helper) (ctrl.Result, error) {
+func (r *OVNNorthdReconciler) reconcileUpdate(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info("Reconciling Service update")
@@ -283,7 +282,7 @@ func (r *OVNNorthdReconciler) reconcileUpdate(ctx context.Context, instance *ovn
 	return ctrl.Result{}, nil
 }
 
-func (r *OVNNorthdReconciler) reconcileUpgrade(ctx context.Context, instance *ovnv1.OVNNorthd, helper *helper.Helper) (ctrl.Result, error) {
+func (r *OVNNorthdReconciler) reconcileUpgrade(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info("Reconciling Service upgrade")
@@ -362,7 +361,7 @@ func (r *OVNNorthdReconciler) reconcileNormal(ctx context.Context, instance *ovn
 	}
 
 	// Handle service update
-	ctrlResult, err := r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err := r.reconcileUpdate(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -370,7 +369,7 @@ func (r *OVNNorthdReconciler) reconcileNormal(ctx context.Context, instance *ovn
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"crypto/tls"
 	"flag"
 	"os"
@@ -120,7 +119,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(mgr, context.Background()); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OVNNorthd")
 		os.Exit(1)
 	}
@@ -136,7 +135,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Kclient: kclient,
 		Scheme:  mgr.GetScheme(),
-	}).SetupWithManager(mgr, context.Background()); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OVNController")
 		os.Exit(1)
 	}

--- a/pkg/ovncontroller/configjob.go
+++ b/pkg/ovncontroller/configjob.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -30,7 +29,6 @@ import (
 // ConfigJob - prepare job to configure ovn-controller
 func ConfigJob(
 	ctx context.Context,
-	h *helper.Helper,
 	k8sClient client.Client,
 	instance *ovnv1.OVNController,
 	sbCluster *ovnv1.OVNDBCluster,

--- a/pkg/ovncontroller/const.go
+++ b/pkg/ovncontroller/const.go
@@ -1,3 +1,1 @@
 package ovncontroller
-
-const ()

--- a/pkg/ovnnorthd/const.go
+++ b/pkg/ovnnorthd/const.go
@@ -1,3 +1,1 @@
 package ovnnorthd
-
-const ()

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //revive:disable:dot-imports
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -62,11 +62,6 @@ func GetTLSOVNNorthdSpec() ovnv1.OVNNorthdSpec {
 		},
 	}
 	return spec
-}
-
-func CreateOVNNorthd(namespace string, OVNNorthdName string, spec ovnv1.OVNNorthdSpec) client.Object {
-	name := ovn.CreateOVNNorthd(namespace, spec)
-	return ovn.GetOVNNorthd(name)
 }
 
 func GetOVNNorthd(name types.NamespacedName) *ovnv1.OVNNorthd {
@@ -109,10 +104,6 @@ func CreateOVNDBCluster(namespace string, spec ovnv1.OVNDBClusterSpec) client.Ob
 	return ovn.GetOVNDBCluster(name)
 }
 
-func UpdateOVNDBCluster(cluster *ovnv1.OVNDBCluster) {
-	k8sClient.Update(ctx, cluster)
-}
-
 func OVNDBClusterConditionGetter(name types.NamespacedName) condition.Conditions {
 	instance := ovn.GetOVNDBCluster(name)
 	return instance.Status.Conditions
@@ -135,7 +126,7 @@ func CreateOVNDBClusters(namespace string, nad map[string][]string, replicas int
 		// OVNDBCluster doesn't allow multiple NADs, hence map len
 		// must be <= 1
 		Expect(len(nad)).Should(BeNumerically("<=", 1))
-		for k, _ := range nad {
+		for k := range nad {
 			if strings.Contains(k, "/") {
 				// k = namespace/nad_name, split[1] will return nad_name (e.g. internalapi)
 				stringNad = strings.Split(k, "/")[1]
@@ -150,7 +141,7 @@ func CreateOVNDBClusters(namespace string, nad map[string][]string, replicas int
 		spec.Replicas = &replicas
 
 		instance := CreateOVNDBCluster(namespace, spec)
-		instance_name := types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+		instanceName := types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 
 		dbName := "nb"
 		if db == ovnv1.SBDBType {
@@ -168,7 +159,7 @@ func CreateOVNDBClusters(namespace string, nad map[string][]string, replicas int
 		// with all information (Status.DBAddress and internalDBAddress
 		// are set at the end of the reconcileService)
 		Eventually(func(g Gomega) {
-			ovndbcluster := ovn.GetOVNDBCluster(instance_name)
+			ovndbcluster := ovn.GetOVNDBCluster(instanceName)
 			endpoint := ""
 			// Check External endpoint when NAD is set
 			if len(nad) == 0 {
@@ -179,7 +170,7 @@ func CreateOVNDBClusters(namespace string, nad map[string][]string, replicas int
 			g.Expect(endpoint).ToNot(BeEmpty())
 		}).Should(Succeed())
 
-		dbs = append(dbs, instance_name)
+		dbs = append(dbs, instanceName)
 
 	}
 
@@ -322,7 +313,7 @@ func GetDNSDataHostsList(namespace string, dnsEntryName string) []infranetworkv1
 	return dnsEntry.Spec.Hosts
 }
 
-func CheckDNSDataContainsIp(namespace string, dnsEntryName string, ip string) bool {
+func CheckDNSDataContainsIP(namespace string, dnsEntryName string, ip string) bool {
 	hostList := GetDNSDataHostsList(namespace, dnsEntryName)
 	for _, host := range hostList {
 		if host.IP == ip {
@@ -342,7 +333,7 @@ func GetPod(name types.NamespacedName) *corev1.Pod {
 }
 
 func UpdatePod(pod *corev1.Pod) {
-	k8sClient.Update(ctx, pod)
+	Expect(k8sClient.Update(ctx, pod)).Should(Succeed())
 }
 
 func GetServicesListWithLabel(namespace string, labelSelectorMap ...map[string]string) *corev1.ServiceList {

--- a/tests/functional/ovncontroller_controller_test.go
+++ b/tests/functional/ovncontroller_controller_test.go
@@ -20,18 +20,19 @@ import (
 	"encoding/json"
 	"fmt"
 
-	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
 	ovn_common "github.com/openstack-k8s-operators/ovn-operator/pkg/common"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	//	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
-	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 )
 
 var _ = Describe("OVNController controller", func() {
@@ -745,7 +746,7 @@ var _ = Describe("OVNController controller", func() {
 
 		It("applies meaningful defaults", func() {
 			ovnController := GetOVNController(ovnControllerName)
-			Expect(*ovnController.Spec.ExternalIDS.EnableChassisAsGateway).To(Equal(true))
+			Expect(*ovnController.Spec.ExternalIDS.EnableChassisAsGateway).To(BeTrue())
 			Expect(ovnController.Spec.ExternalIDS.OvnEncapType).To(Equal("geneve"))
 			Expect(ovnController.Spec.ExternalIDS.OvnBridge).To(Equal("br-int"))
 			Expect(ovnController.Spec.ExternalIDS.SystemID).To(Equal("random"))

--- a/tests/functional/ovndbcluster_controller_test.go
+++ b/tests/functional/ovndbcluster_controller_test.go
@@ -20,11 +20,14 @@ import (
 	"encoding/json"
 	"fmt"
 
-	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,8 +60,8 @@ var _ = Describe("OVNDBCluster controller", func() {
 					}
 
 					Eventually(func(g Gomega) int {
-						DnsHostsList := GetDNSDataHostsList(statefulSetName.Namespace, "ovsdbserver-"+DnsName)
-						return len(DnsHostsList)
+						DNSHostsList := GetDNSDataHostsList(statefulSetName.Namespace, "ovsdbserver-"+DnsName)
+						return len(DNSHostsList)
 					}).Should(BeNumerically("==", 3))
 
 					// Scale down to 1
@@ -70,8 +73,8 @@ var _ = Describe("OVNDBCluster controller", func() {
 
 					// Check if dnsdata CR is down to 1
 					Eventually(func() int {
-						listDns := GetDNSDataHostsList(statefulSetName.Namespace, "ovsdbserver-"+DnsName)
-						return len(listDns)
+						listDNS := GetDNSDataHostsList(statefulSetName.Namespace, "ovsdbserver-"+DnsName)
+						return len(listDNS)
 					}).Should(BeNumerically("==", 1))
 				},
 				Entry("DNS entry NB", "nb"),
@@ -92,14 +95,14 @@ var _ = Describe("OVNDBCluster controller", func() {
 
 					// Check that DNSData info has been created with correct IP (10.0.0.1)
 					Eventually(func(g Gomega) {
-						g.Expect(CheckDNSDataContainsIp(cluster.Namespace, "ovsdbserver-sb", "10.0.0.1")).Should(BeTrue())
+						g.Expect(CheckDNSDataContainsIP(cluster.Namespace, "ovsdbserver-sb", "10.0.0.1")).Should(BeTrue())
 					}).Should(Succeed())
 
 					// Modify pod IP section
 					pod := GetPod(types.NamespacedName{Name: "ovsdbserver-sb-0", Namespace: cluster.Namespace})
 					// Create new pod NAD and add it to POD
 					netStatus := []networkv1.NetworkStatus{
-						networkv1.NetworkStatus{
+						{
 							Name: cluster.Namespace + "/internalapi",
 							IPs:  []string{"10.0.0.10"},
 						},
@@ -114,13 +117,13 @@ var _ = Describe("OVNDBCluster controller", func() {
 					Eventually(func(g Gomega) {
 						c := GetOVNDBCluster(clusterName)
 						// Change something just to call reconcile loop
-						*&c.Spec.ElectionTimer += 1000
+						c.Spec.ElectionTimer += 1000
 						g.Expect(k8sClient.Update(ctx, c)).Should(Succeed())
 					}).Should(Succeed())
 
 					// Check that DNSData info has been modified with correct IP (10.0.0.10)
 					Eventually(func(g Gomega) {
-						g.Expect(CheckDNSDataContainsIp(cluster.Namespace, "ovsdbserver-sb", "10.0.0.1")).Should(BeTrue())
+						g.Expect(CheckDNSDataContainsIP(cluster.Namespace, "ovsdbserver-sb", "10.0.0.1")).Should(BeTrue())
 					}).Should(Succeed())
 
 				},
@@ -238,18 +241,18 @@ var _ = Describe("OVNDBCluster controller", func() {
 			// - ovsdbserver-sb-0 (cluster type)
 			Eventually(func(g Gomega) {
 				serviceListWithoutTypeLabel := GetServicesListWithLabel(namespace)
-				g.Expect(len(serviceListWithoutTypeLabel.Items)).To(Equal(2))
+				g.Expect(serviceListWithoutTypeLabel.Items).To(HaveLen(2))
 			}).Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				serviceListWithClusterType := GetServicesListWithLabel(namespace, map[string]string{"type": "cluster"})
-				g.Expect(len(serviceListWithClusterType.Items)).To(Equal(1))
+				g.Expect(serviceListWithClusterType.Items).To(HaveLen(1))
 				g.Expect(serviceListWithClusterType.Items[0].Name).To(Equal("ovsdbserver-sb-0"))
 			}).Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				serviceListWithHeadlessType := GetServicesListWithLabel(namespace, map[string]string{"type": "headless"})
-				g.Expect(len(serviceListWithHeadlessType.Items)).To(Equal(1))
+				g.Expect(serviceListWithHeadlessType.Items).To(HaveLen(1))
 				g.Expect(serviceListWithHeadlessType.Items[0].Name).To(Equal("ovsdbserver-sb"))
 			}).Should(Succeed())
 		})

--- a/tests/functional/ovnnorthd_controller_test.go
+++ b/tests/functional/ovnnorthd_controller_test.go
@@ -20,14 +20,16 @@ import (
 	"encoding/json"
 	"fmt"
 
-	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 )
 
 var _ = Describe("OVNNorthd controller", func() {

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -25,10 +25,11 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -172,7 +173,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(k8sManager, context.Background())
+	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.OVNDBClusterReconciler{
@@ -186,7 +187,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(k8sManager, context.Background())
+	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Acquire environmental defaults and initialize operator defaults with them


### PR DESCRIPTION
* removed unused funcs, func params and imports
* ignore revive dot-imports rule on ginkgo and gomega as dot import
there is the recommended practice
* various small style fixes found by the linter
