### PR TITLE
DBCluster: remove explicit status update

### DIFF
--- a/controllers/ovndbcluster_controller.go
+++ b/controllers/ovndbcluster_controller.go
@@ -823,9 +823,6 @@ func (r *OVNDBClusterReconciler) createHashOfInputHashes(
 	}
 	if hashMap, changed := util.SetHash(instance.Status.Hash, common.InputHashName, hash); changed {
 		instance.Status.Hash = hashMap
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return hash, err
-		}
 		Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
 	}
 	return hash, nil


### PR DESCRIPTION
To make it easier to reason about when the instance is updated this
patch removes the explicit status update form the input hash generation
code path and let the controller rely on the deferred PatchInstance call
as the only place where the instance is persisted.

The removed code probably didn't cause any trouble as it only updated
the status subresource and all the non status update (the self finalizer)
is guarded with an explicit return from the reconciler. So no non status
update is lost due to this status update. Still this cleanup might help
avoiding future issues.
