### PR TITLE
Fix default handling for LogLevel param

### DIFF
--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -83,7 +83,7 @@ type OVNDBClusterSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=info
 	// LogLevel - Set log level info, dbg, emer etc
-	LogLevel string `json:"logLevel"`
+	LogLevel string `json:"logLevel,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=10000

--- a/api/v1beta1/ovnnorthd_types.go
+++ b/api/v1beta1/ovnnorthd_types.go
@@ -59,7 +59,7 @@ type OVNNorthdSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=info
 	// LogLevel - Set log level info, dbg, emer etc
-	LogLevel string `json:"logLevel"`
+	LogLevel string `json:"logLevel,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// Resources - Compute Resources required by this service (Limits/Requests).

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -43,11 +43,7 @@ const (
 
 func GetDefaultOVNNorthdSpec() ovnv1.OVNNorthdSpec {
 	return ovnv1.OVNNorthdSpec{
-		OVNNorthdSpecCore: ovnv1.OVNNorthdSpecCore{
-			// TODO: Create() doesn't apply kubebuilder defaults, in contrast to
-			// CreateUnstructured for some reason; need to understand why
-			LogLevel: "info",
-		},
+		OVNNorthdSpecCore: ovnv1.OVNNorthdSpecCore{},
 	}
 }
 
@@ -76,10 +72,7 @@ func OVNNorthdConditionGetter(name types.NamespacedName) condition.Conditions {
 func GetDefaultOVNDBClusterSpec() ovnv1.OVNDBClusterSpec {
 	return ovnv1.OVNDBClusterSpec{
 		OVNDBClusterSpecCore: ovnv1.OVNDBClusterSpecCore{
-			DBType: ovnv1.NBDBType,
-			// TODO: Create() doesn't apply kubebuilder defaults, in contrast to
-			// CreateUnstructured for some reason; need to understand why
-			LogLevel:       "info",
+			DBType:         ovnv1.NBDBType,
 			StorageRequest: "1G",
 			StorageClass:   "local-storage",
 		},


### PR DESCRIPTION
When OVNDBCluster or OVNNorthd CR is created with empty spec with golang structs(as done in functional tests or in openstack-operator) the golang defaults get's applied as per type, in this case logLevel being string type an empty string("") get's set and that leads to kubebuilder default("info") not honored.

[1] provide more details on this behavior as kubebuilder default is different here then the golang default for the string type. Handle it by adding omitempty field, with this "" as empty value will be discarded and kubebuilder defaults will work.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1568
[1] https://github.com/gibizer/operator-lint/tree/main/linters/crd/C003
Closes: [OSPRH-6597](https://issues.redhat.com//browse/OSPRH-6597)