### PR TITLE
Set fips-compliant CRD feature flag

### DIFF
--- a/config/manifests/bases/ovn-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ovn-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/disconnected: "true"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone


### PR DESCRIPTION
This change adds the feature flag to indicate that our operator is fips compliant.