### PR TITLE
[ovnController] Handle nicMappings with dashes

### DIFF
--- a/config/samples/nad_data-centre3.yaml
+++ b/config/samples/nad_data-centre3.yaml
@@ -3,14 +3,14 @@ kind: NetworkAttachmentDefinition
 metadata:
   annotations:
   labels:
-    osp/net: datacentre3
+    osp/net: data-centre3
     service: ovn-controller
-  name: datacentre3
+  name: data-centre3
 spec:
   config: |
     {
       "cniVersion": "0.3.1",
-      "name": "datacentre3",
+      "name": "data-centre3",
       "type": "bridge",
       "bridge": "ospbr3",
       "ipam": {}

--- a/templates/ovncontroller/bin/functions
+++ b/templates/ovncontroller/bin/functions
@@ -69,7 +69,7 @@ function configure_physical_networks {
     for physicalNetwork in ${PhysicalNetworks}; do
         br_name="br-${physicalNetwork}"
         bridgeMapping="${physicalNetwork}:${br_name}"
-        if [ -z "$OvnBridgeMappings"]; then
+        if [ -z "$OvnBridgeMappings" ]; then
             OvnBridgeMappings=$bridgeMapping
             br_new=$br_name
         else
@@ -98,7 +98,7 @@ function configure_physical_networks {
     # Add the new bridges.
     for br_name in ${br_to_add}; do
         ovs-vsctl --may-exist add-br ${br_name}
-        ovs-vsctl --may-exist add-port ${br_name} ${br_name##*-}
+        ovs-vsctl --may-exist add-port ${br_name} ${br_name#*-}
     done
 
     # Delete the old bridges not longer present in "OvnBridgeMappings" and the

--- a/tests/kuttl/common/cleanup-ovn.yaml
+++ b/tests/kuttl/common/cleanup-ovn.yaml
@@ -18,4 +18,4 @@ delete:
   name: datacentre2
 - apiVersion: k8s.cni.cncf.io/v1
   kind: NetworkAttachmentDefinition
-  name: datacentre3
+  name: data-centre3

--- a/tests/kuttl/tests/ovn_nicmappings/02-new-network-attachment-definition.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/02-new-network-attachment-definition.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 commands:
   - script: |
       oc apply -n $NAMESPACE -f ../../../../config/samples/nad_datacentre2.yaml
-      oc apply -n $NAMESPACE -f ../../../../config/samples/nad_datacentre3.yaml
+      oc apply -n $NAMESPACE -f ../../../../config/samples/nad_data-centre3.yaml

--- a/tests/kuttl/tests/ovn_nicmappings/03-assert.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/03-assert.yaml
@@ -12,7 +12,8 @@ commands:
         controller_pod=$(oc get pod -n $NAMESPACE -l service=ovn-controller-ovs -o name|head -1)
         oc rsh -n $NAMESPACE ${controller_pod} ip link show dev datacentre2 || exit 1
         oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-datacentre2 || exit 1
-        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev datacentre3 2>&1 | grep "does not exist" || exit 1
-        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-datacentre3 2>&1 | grep "does not exist" || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ovs-vsctl list-ports br-datacentre2 | grep datacentre2 || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev data-centre3 2>&1 | grep "does not exist" || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-data-centre3 2>&1 | grep "does not exist" || exit 1
         oc rsh -n $NAMESPACE ${controller_pod} ovs-vsctl --if-exists get open . external_ids:ovn-bridge-mappings | grep -q "datacentre2:br-datacentre2" || exit 1
         exit 0

--- a/tests/kuttl/tests/ovn_nicmappings/04-assert.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/04-assert.yaml
@@ -1,7 +1,7 @@
 #
 # Check for:
 #
-# - The interface "datacentre3" exists in the ovn-controller container
+# - The interface "data-centre3" exists in the ovn-controller container
 # - The interface "datacentre2" no longer exists in the ovn-controller container
 # - The OVS Open vSwitch external_ids:ovn-bridge-mappings is configured correctly
 
@@ -11,8 +11,9 @@ timeout: 300
 commands:
     - script: |
         controller_pod=$(oc get pod -n $NAMESPACE -l service=ovn-controller-ovs -o name|head -1)
-        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev datacentre3 || exit 1
-        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-datacentre3 || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev data-centre3 || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-data-centre3 || exit 1
+        oc rsh -n $NAMESPACE ${controller_pod} ovs-vsctl list-ports br-data-centre3 | grep data-centre3 || exit 1
         oc rsh -n $NAMESPACE ${controller_pod} ip link show dev datacentre2 2>&1 | grep "does not exist" || exit 1
         oc rsh -n $NAMESPACE ${controller_pod} ip link show dev br-datacentre2 2>&1 | grep "does not exist" || exit 1
         oc rsh -n $NAMESPACE ${controller_pod} ovs-vsctl --if-exists get open . external_ids:ovn-bridge-mappings | grep "datacentre2:br-datacentre2" && exit 1

--- a/tests/kuttl/tests/ovn_nicmappings/04-nicmappings-patch-datacentre3.yaml
+++ b/tests/kuttl/tests/ovn_nicmappings/04-nicmappings-patch-datacentre3.yaml
@@ -6,5 +6,5 @@ commands:
       oc patch OVNController -n $NAMESPACE ovncontroller-sample --type='json' -p='[{
         "op": "replace",
         "path": "/spec/nicMappings",
-        "value":{"datacentre3":"ospbr3"}
+        "value":{"data-centre3":"ospbr3"}
       }]'


### PR DESCRIPTION
Currently it do not work if nicMappings contain
dashes as port name is wrongly detected, like
for nicMappings: {"dpdk-data0": "ospbr"}, bridge
name get's "br-dpdk-data0" while port name as
"data0" instead of "dpdk-data0", this patch fixes
it.

It got missed while fixing other issue[1].

Also fixed some syntax errors and updated kuttl tests to include this case.

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/248

Related-Issue: [OSPRH-7130](https://issues.redhat.com//browse/OSPRH-7130)
Related-Issue: [OSPRH-3124](https://issues.redhat.com//browse/OSPRH-3124)