### PR TITLE
Remove non graceful OVN DB pod delete Kuttl test

### DIFF
--- a/tests/kuttl/tests/ovn_db_delete/06-assert.yaml
+++ b/tests/kuttl/tests/ovn_db_delete/06-assert.yaml
@@ -1,1 +1,0 @@
-02-assert.yaml

--- a/tests/kuttl/tests/ovn_db_delete/06-delete-pods-non-graceful.yaml
+++ b/tests/kuttl/tests/ovn_db_delete/06-delete-pods-non-graceful.yaml
@@ -1,7 +1,0 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: |
-      oc delete pods -n $NAMESPACE -l service=ovsdbserver-nb --force --grace-period=0
-  - script: |
-      oc delete pods -n $NAMESPACE -l service=ovsdbserver-sb --force --grace-period=0


### PR DESCRIPTION
We are seeing a failure with the `06-delete-pods-non-graceful.yaml` job
in OCP 4.15 Prow CI. After discussing with the ovn-operator maintainers
we decided this test is invalid. With both `--force` and
`--grace-period=0` the database lock file is not being released and this
is something that requires hands on recovery which isn't being covered in
this test case.

JIRA: https://issues.redhat.com/browse/OSPRH-7515