### PR TITLE
Fix NAD handling on create/update

### DIFF
--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -441,8 +441,8 @@ func (r *OVNControllerReconciler) reconcileNormal(ctx context.Context, instance 
 		common.AppSelector: ovnv1.ServiceNameOVS,
 	}
 
-	// Create additional Physical Network Attachments
-	networkAttachments, err := ovncontroller.CreateAdditionalNetworks(ctx, helper, instance, ovsServiceLabels)
+	// Create or Update additional Physical Network Attachments
+	networkAttachments, err := ovncontroller.CreateOrUpdateAdditionalNetworks(ctx, helper, instance, ovsServiceLabels)
 	if err != nil {
 		Log.Info(fmt.Sprintf("Failed to create additional networks: %s", err))
 		return ctrl.Result{}, err

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega" //revive:disable:dot-imports
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -289,6 +290,32 @@ func SimulateDaemonsetNumberReadyWithPods(name types.NamespacedName, networkIPs 
 	}, timeout, interval).Should(Succeed())
 
 	logger.Info("Simulated daemonset success", "on", name)
+}
+
+func CreateNAD(name types.NamespacedName) *networkv1.NetworkAttachmentDefinition {
+	nad := &networkv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+		},
+		Spec: networkv1.NetworkAttachmentDefinitionSpec{
+			Config: "",
+		},
+	}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Create(ctx, nad)).Should(Succeed())
+	}).Should(Succeed())
+
+	return nad
+}
+
+func GetNAD(name types.NamespacedName) *networkv1.NetworkAttachmentDefinition {
+	nad := &networkv1.NetworkAttachmentDefinition{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, nad)).Should(Succeed())
+	}).Should(Succeed())
+
+	return nad
 }
 
 func GetDNSData(name types.NamespacedName) *infranetworkv1.DNSData {


### PR DESCRIPTION
Currently only NAD creation was handled for the provided
nicMappings, this patch allows update to the nads.

Added missing ownership to the managed net-attach-defs
so they get's controlled with OVNController reconciler if
deleted/updated explicitly.

Also added functional tests and fixed some log messages.

Closes-Issue: [OSPRH-6894](https://issues.redhat.com//browse/OSPRH-6894)