### PR TITLE
Use OVSNumberReady for evaluating NetworkAttachment Readiness

### DIFF
--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -562,7 +562,7 @@ func (r *OVNControllerReconciler) reconcileNormal(ctx context.Context, instance 
 	instance.Status.OVSNumberReady = ovsdset.GetDaemonSet().Status.NumberReady
 
 	// verify if network attachment matches expectations
-	networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(ctx, helper, networkAttachmentsNoPhysNet, ovsServiceLabels, instance.Status.NumberReady)
+	networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(ctx, helper, networkAttachmentsNoPhysNet, ovsServiceLabels, instance.Status.OVSNumberReady)
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
NumberReady status field was used currently but that's for ovn-controller but we don't attach secondary nics to it.

Use correct status field i.e OVSNumberReady. This should also fix random failues in functional test which check for NetworkAttachment condition.