### PR TITLE
[kuttl test] Fix label for ovs pods

### DIFF
--- a/tests/kuttl/common/errors_cleanup_ovn.yaml
+++ b/tests/kuttl/common/errors_cleanup_ovn.yaml
@@ -90,7 +90,7 @@ metadata:
     openshift.io/scc: privileged
   generateName: ovn-controller-ovs-
   labels:
-    service: ovn-controller
+    service: ovn-controller-ovs
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Was missed in [1]. The left over pods can conflict
with next scenario test run.

[1] https://github.com/openstack-k8s-operators/ovn-operator/commit/2605c18
Related-Issue: [OSPRH-1932](https://issues.redhat.com//browse/OSPRH-1932)