### PR TITLE
Add required csv annotations. Remove deprecated

### DIFF
--- a/config/manifests/bases/ovn-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ovn-operator.clusterserviceversion.yaml
@@ -6,7 +6,11 @@ metadata:
     capabilities: Basic Install
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operators.operatorframework.io/operator-type: non-standalone
   name: ovn-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
Removing: 
`operators.openshift.io/infrastructure-features: ["disconnected"]` is deprecated starting with OpenShift 4.14
The `features.operators.openshift.io/disconnected: "true"` annotation is already present as its replacament

Adding newly required csv annotations. Set to "false" to indicate this operator does not support them

Implements: https://issues.redhat.com/browse/OSPRH-7931