### PR TITLE
Gracefully handle empty db file on startup

### DIFF
--- a/templates/ovndbcluster/bin/cleanup.sh
+++ b/templates/ovndbcluster/bin/cleanup.sh
@@ -14,9 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 set -ex
+source $(dirname $0)/functions
 
 DB_NAME="OVN_Northbound"
-DB_TYPE="{{ .DB_TYPE }}"
 if [[ "${DB_TYPE}" == "sb" ]]; then
     DB_NAME="OVN_Southbound"
 fi
@@ -42,5 +42,5 @@ fi
 # leaving the database file intact for -0 pod.
 if [[ "$(hostname)" != "{{ .SERVICE_NAME }}-0" ]]; then
     # now that we left, the database file is no longer valid
-    rm -f /etc/ovn/ovn${DB_TYPE}_db.db
+    cleanup_db_file
 fi

--- a/templates/ovndbcluster/bin/functions
+++ b/templates/ovndbcluster/bin/functions
@@ -1,0 +1,20 @@
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+DB_TYPE="{{ .DB_TYPE }}"
+DB_FILE=/etc/ovn/ovn${DB_TYPE}_db.db
+
+function cleanup_db_file() {
+    rm -f $DB_FILE
+}

--- a/templates/ovndbcluster/bin/setup.sh
+++ b/templates/ovndbcluster/bin/setup.sh
@@ -14,7 +14,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 set -ex
-DB_TYPE="{{ .DB_TYPE }}"
+source $(dirname $0)/functions
+
 DB_PORT="{{ .DB_PORT }}"
 {{- if .TLS }}
 DB_SCHEME="pssl"
@@ -79,6 +80,12 @@ set "$@" --ovn-${DB_TYPE}-log=-vconsole:{{ .OVN_LOG_LEVEL }}
 # create a log file -> this argument makes sure it doesn't polute OVN_LOGDIR
 # with a nearly empty log file
 set "$@" --ovn-${DB_TYPE}-logfile=/dev/null
+
+# If db file is empty, remove it; otherwise service won't start.
+# See https://issues.redhat.com/browse/FDP-689 for more details.
+if ! [ -s $DB_FILE ]; then
+    cleanup_db_file
+fi
 
 # don't log to file (we already log to console)
 $@ ${OPTS} run_${DB_TYPE}_ovsdb -- -vfile:off &


### PR DESCRIPTION
In some situations, e.g. when ovsdb-tool is killed during db file initialization, the file may end up empty. On next restart, the service fails to start because the file format is invalid.

Ideally, ovs start scripts would handle this situation gracefully, as tracked in https://issues.redhat.com/browse/FDP-689

But in the meantime, we can also handle the situation on operator's side, by removing the empty file if present.

FYI a valid file always contains at least some data, because ovsdb-tool adds a log entry with raft config as the first entry. See:

https://github.com/openvswitch/ovs/blob/56e315937eeb640d5d8f305988d133390445eaee/ovsdb/raft.c#L525

Resolves: https://issues.redhat.com/browse/OSPRH-8117