### PR TITLE
 Wait for the ovsdb-tool when stopping the OVNDBCluster

### DIFF
--- a/pkg/ovndbcluster/statefulset.go
+++ b/pkg/ovndbcluster/statefulset.go
@@ -57,7 +57,7 @@ func StatefulSet(
 
 	var preStopCmd []string
 	cmd := []string{"/usr/bin/dumb-init"}
-	args := []string{"--single-child", "--", "/bin/bash", "-c", ServiceCommand}
+	args := []string{"--", "/bin/bash", "-c", ServiceCommand}
 	//
 	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 	//

--- a/templates/ovndbcluster/bin/functions
+++ b/templates/ovndbcluster/bin/functions
@@ -18,3 +18,10 @@ DB_FILE=/etc/ovn/ovn${DB_TYPE}_db.db
 function cleanup_db_file() {
     rm -f $DB_FILE
 }
+
+function wait_for_ovsdb_tool {
+    while pgrep -a ovsdb-tool; do
+        echo "ovsdb-tool still working. Waiting..."
+        sleep 1
+    done
+}

--- a/templates/ovndbcluster/bin/setup.sh
+++ b/templates/ovndbcluster/bin/setup.sh
@@ -87,6 +87,9 @@ if ! [ -s $DB_FILE ]; then
     cleanup_db_file
 fi
 
+# Wait until the ovsdb-tool finishes.
+trap wait_for_ovsdb_tool EXIT
+
 # don't log to file (we already log to console)
 $@ ${OPTS} run_${DB_TYPE}_ovsdb -- -vfile:off &
 
@@ -128,5 +131,8 @@ if [[ "$(hostname)" == "{{ .SERVICE_NAME }}-0" ]]; then
     kill $(cat $OVN_RUNDIR/ovn-${DB_TYPE}ctl.pid)
     unset OVN_${DB_TYPE^^}_DAEMON
 fi
+
+wait_for_ovsdb_tool
+trap - EXIT
 
 wait


### PR DESCRIPTION
It could happen that the pod is restarted before the ovsdb-tool
finishes the creation of the database. The start script running
on the OVNDBCluster pods now waits for the ovsdb-tool to finish if
an EXIT signal is received.

Closes-Issue: [OSPRH-8212](https://issues.redhat.com//browse/OSPRH-8212)