### PR TITLE
[ovsdb-server] Move db initialization to an init container

### DIFF
--- a/templates/ovncontroller/bin/init-ovsdb-server.sh
+++ b/templates/ovncontroller/bin/init-ovsdb-server.sh
@@ -15,15 +15,8 @@
 # under the License.
 
 set -ex
-source $(dirname $0)/functions
 
-# Remove the obsolete semaphore file in case it still exists.
-cleanup_ovsdb_server_semaphore
-
-# Start the service
-ovsdb-server /etc/openvswitch/conf.db \
-    --pidfile \
-    --remote=punix:/var/run/openvswitch/db.sock \
-    --private-key=db:Open_vSwitch,SSL,private_key \
-    --certificate=db:Open_vSwitch,SSL,certificate \
-    --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert
+# Initialize or upgrade database if needed
+CTL_ARGS="--system-id=random --no-ovs-vswitchd"
+/usr/share/openvswitch/scripts/ovs-ctl start $CTL_ARGS
+/usr/share/openvswitch/scripts/ovs-ctl stop $CTL_ARGS

--- a/tests/functional/ovncontroller_controller_test.go
+++ b/tests/functional/ovncontroller_controller_test.go
@@ -890,6 +890,36 @@ var _ = Describe("OVNController controller", func() {
 			)
 		})
 
+		It("OVS Daemonset is created with 3 containers including an init container", func() {
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(types.NamespacedName{
+				Name:      CABundleSecretName,
+				Namespace: namespace,
+			}))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(types.NamespacedName{
+				Name:      OvnDbCertSecretName,
+				Namespace: namespace,
+			}))
+
+			daemonSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			}
+
+			SimulateDaemonsetNumberReady(daemonSetName)
+
+			daemonSetNameOVS := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			}
+
+			SimulateDaemonsetNumberReady(daemonSetNameOVS)
+
+			ds := GetDaemonSet(daemonSetNameOVS)
+
+			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(2))
+		})
+
 		It("creates a Daemonset with TLS certs attached", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(types.NamespacedName{
 				Name:      CABundleSecretName,


### PR DESCRIPTION
There is a potential race condition where ovs-vswitchd containers can run ovs db commands and fails while ovsdb-server stops and restarts after db initialization. This makes ovs-vswitchd container to fail and restart and it eventually recovers and it's better to avoid this.

This patch moves the db initialization part to init container to avoid this race.

Resolves: [OSPRH-637](https://issues.redhat.com//browse/OSPRH-637)