### PR TITLE
Move external config map generation to OVNDBCluster

### DIFF
--- a/api/v1beta1/client.go
+++ b/api/v1beta1/client.go
@@ -52,6 +52,26 @@ func getDBClusters(
 	return ovnDBList, nil
 }
 
+func GetOVNController(
+	ctx context.Context,
+	h *helper.Helper,
+	namespace string,
+) (*OVNController, error) {
+	ovnControllerList := &OVNControllerList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+	}
+	err := h.GetClient().List(ctx, ovnControllerList, listOpts...)
+	if err != nil {
+		return nil, err
+	}
+	if len(ovnControllerList.Items) > 0 {
+		return &ovnControllerList.Items[0], nil
+	}
+
+	return nil, nil
+}
+
 // GetDBClusterByType - return OVNDBCluster for the given dbType
 func GetDBClusterByType(
 	ctx context.Context,
@@ -87,8 +107,8 @@ func getItems(list client.ObjectList) []client.Object {
 	return items
 }
 
-// OVNDBClusterNamespaceMapFunc - DBCluster Watch Function
-func OVNDBClusterNamespaceMapFunc(crs client.ObjectList, reader client.Reader) handler.MapFunc {
+// OVNCRNamespaceMapFunc // Generic function to watch any OVN CR
+func OVNCRNamespaceMapFunc(crs client.ObjectList, reader client.Reader) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
 		log := log.FromContext(ctx)
 		result := []reconcile.Request{}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -146,6 +146,12 @@ rules:
 - apiGroups:
   - ovn.openstack.org
   resources:
+  - ovncontroller
+  verbs:
+  - watch
+- apiGroups:
+  - ovn.openstack.org
+  resources:
   - ovncontrollers
   verbs:
   - create

--- a/controllers/ovnnorthd_controller.go
+++ b/controllers/ovnnorthd_controller.go
@@ -212,7 +212,7 @@ func (r *OVNNorthdReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
-		Watches(&ovnv1.OVNDBCluster{}, handler.EnqueueRequestsFromMapFunc(ovnv1.OVNDBClusterNamespaceMapFunc(crs, mgr.GetClient()))).
+		Watches(&ovnv1.OVNDBCluster{}, handler.EnqueueRequestsFromMapFunc(ovnv1.OVNCRNamespaceMapFunc(crs, mgr.GetClient()))).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),

--- a/templates/ovndbcluster/config/ovsdb-config
+++ b/templates/ovndbcluster/config/ovsdb-config
@@ -1,2 +1,4 @@
 ovn-remote: {{ .OVNRemote }}
+{{if (index . "OVNEncapType")}}
 ovn-encap-type: {{ .OVNEncapType }}
+{{end}}

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -235,6 +235,10 @@ func CreateOVNController(namespace string, spec ovnv1.OVNControllerSpec) client.
 	return ovn.GetOVNController(name)
 }
 
+func DeleteOVNController(instance types.NamespacedName) {
+	th.DeleteInstance(ovn.GetOVNController(instance))
+}
+
 func GetOVNController(name types.NamespacedName) *ovnv1.OVNController {
 	return ovn.GetOVNController(name)
 }


### PR DESCRIPTION
Currently the external config map consumed by edpm deployment is generated on ovn-controller. 
Due to the fact that the environment can be set without deploying ovn-controller (if nicMappings is empty there's no need to spawn it) the config map wouldn't be created. Since this config map is needed by the edpm deployment it's creation has been moved from ovn-controller to ovndbcluster. 

Resolves: [OSPRH-10372](https://issues.redhat.com//browse/OSPRH-10372)
Related-Issue: [OSPRH-7463](https://issues.redhat.com//browse/OSPRH-7463)

Resolves: https://github.com/openstack-k8s-operators/openstack-operator/pull/1070