### PR TITLE
OWNERS: Drop beagles from approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,7 +6,6 @@ aliases:
   - frenzyfriday
   - viroel
   network-approvers:
-  - beagles
   - booxter
   - karelyatin
   - slawqo


### PR DESCRIPTION
There's a single patch by the approver in the repo, I suggest to reflect the reality that this repo is not something the contributor is focused on.