### PR TITLE
Bump kuttl tests timeout to 6 minutes

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -19,7 +19,7 @@ kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-ovn
 namespace: openstack
-timeout: 180
+timeout: 360
 parallel: 1
 suppress:
   - events                     # Remove spammy event logs


### PR DESCRIPTION
We hit random issue in ovn_db_delete kuttl
test where we delete db pods, and if pod-0 get's
deleted first other pods stuck in terminating
state for 5 minutes(graceful terminate time)
before getting killed. In order to workaround
the issue increasing the test timeout, can be
reverted when the issue is actually fixed.

Related-Issue: [OSPRH-7626](https://issues.redhat.com//browse/OSPRH-7626)