### PR TITLE
Add Liveness and Readiness probes to ovn-controller

### DIFF
--- a/templates/ovncontroller/bin/ovn_controller_liveness.sh
+++ b/templates/ovncontroller/bin/ovn_controller_liveness.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+error_exit() {
+    echo "$1" >&2
+    exit 1
+}
+
+# Check if ovn-controller is running
+check_ovn_controller_pid() {
+    if ! pidof -q ovn-controller; then
+        error_exit "ERROR - ovn-controller is not running"
+    fi
+}
+
+# Function to check the running status of ovn-controller
+check_ovn_controller_status() {
+    # Capture output and check exit status
+    if ! output=$(ovn-appctl -t ovn-controller debug/status 2>&1); then
+        error_exit "ERROR - Failed to get status from ovn-controller, ovn-appctl exit status: $?"
+    fi
+
+    if [ "$output" != "running" ]; then
+        error_exit "ERROR - ovn-controller status is '$output', expecting 'running' status"
+    fi
+}
+
+
+check_ovn_controller_pid
+check_ovn_controller_status

--- a/templates/ovncontroller/bin/ovn_controller_readiness.sh
+++ b/templates/ovncontroller/bin/ovn_controller_readiness.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+error_exit() {
+    echo "$1" >&2
+    exit 1
+}
+
+# Check if ovn-controller is connected to the OVN SB database
+check_ovn_controller_connection() {
+    if ! output=$(ovn-appctl -t ovn-controller connection-status 2>&1); then
+        error_exit "ERROR - Failed to get connection status from ovn-controller, ovn-appctl exit status: $?"
+    fi
+
+    if [ "$output" != "connected" ]; then
+        error_exit "ERROR - ovn-controller connection status is '$output', expecting 'connected' status"
+    fi
+}
+
+
+check_ovn_controller_connection

--- a/templates/ovncontroller/bin/ovsdb_server_liveness.sh
+++ b/templates/ovncontroller/bin/ovsdb_server_liveness.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+error_exit() {
+    echo "$1" >&2
+    exit 1
+}
+
+# Check if ovsdb-server is running
+check_ovsdb_server_pid() {
+    if ! pidof -q ovsdb-server; then
+        error_exit "ERROR - ovsdb-server is not running"
+    fi
+}
+
+# Function to check the running status of ovsdb-server
+check_ovsdb_server_status() {
+    if ! /usr/bin/ovs-vsctl show 2>&1; then
+        error_exit "ERROR - Failed to get output from ovsdb-server, ovs-vsctl exit status: $?"
+    fi
+}
+
+
+check_ovsdb_server_pid
+check_ovsdb_server_status

--- a/templates/ovncontroller/bin/ovsdb_server_readiness.sh
+++ b/templates/ovncontroller/bin/ovsdb_server_readiness.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+error_exit() {
+    echo "$1" >&2
+    exit 1
+}
+
+# Check ovsdb-server status
+check_ovsdb_server_status() {
+
+    if ! pid=$(cat /var/run/openvswitch/ovsdb-server.pid); then
+        error_exit "ERROR - Failed to get pid for ovsdb-server, exit status: $?"
+    fi
+
+    if ! output=$(ovs-appctl -t /var/run/openvswitch/ovsdb-server."$pid".ctl ovsdb-server/list-dbs); then
+        error_exit "ERROR - Failed retrieving list of databases from ovsdb-server"
+    fi
+
+    if [[ "$output" != *"Open_vSwitch"* ]]; then
+        error_exit "ERROR - 'Open_vSwitch' not found on databases"
+    fi
+}
+
+check_ovsdb_server_status

--- a/templates/ovncontroller/bin/vswitchd_liveness.sh
+++ b/templates/ovncontroller/bin/vswitchd_liveness.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+error_exit() {
+    echo "$1" >&2
+    exit 1
+}
+
+# Check if ovs-vswitchd is running
+check_ovs_vswitchd_pid() {
+    if ! pidof -q ovs-vswitchd; then
+        error_exit "ERROR - ovs-vswitchd is not running"
+    fi
+}
+
+# Function to check the running status of ovs-vswitchd
+check_ovs_vswitchd_status() {
+    if ! /usr/bin/ovs-appctl bond/show 2>&1; then
+        error_exit "ERROR - Failed to get output from ovs-vswitchd, ovs-appctl exit status: $?"
+    fi
+}
+
+
+check_ovs_vswitchd_pid
+check_ovs_vswitchd_status

--- a/templates/ovncontroller/bin/vswitchd_readiness.sh
+++ b/templates/ovncontroller/bin/vswitchd_readiness.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+error_exit() {
+    echo "$1" >&2
+    exit 1
+}
+
+# Check ovs-vswitchd status
+check_ovs_vswitchd_status() {
+
+    if ! pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid); then
+        error_exit "ERROR - Failed to get pid for ovs-vswitchd, exit status: $?"
+    fi
+
+    if ! output=$(ovs-appctl -t /var/run/openvswitch/ovs-vswitchd."$pid".ctl ofproto/list); then
+        error_exit "ERROR - Failed retrieving ofproto/list from ovs-vswitchd"
+    fi
+
+    if [ -z "$output" ]; then
+        error_exit "ERROR - No bridges on ofproto/list output"
+    fi
+}
+
+check_ovs_vswitchd_status

--- a/tests/functional/ovncontroller_controller_test.go
+++ b/tests/functional/ovncontroller_controller_test.go
@@ -117,6 +117,44 @@ var _ = Describe("OVNController controller", func() {
 			)
 		})
 
+		It("should have a liveness probe configured", func() {
+
+			daemonSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			}
+			ds := GetDaemonSet(daemonSetName)
+
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+
+			daemonSetNameOVS := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			}
+			ds = GetDaemonSet(daemonSetNameOVS)
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].LivenessProbe).ShouldNot(BeNil())
+
+		})
+		It("should have a readiness probe configured", func() {
+
+			daemonSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			}
+			ds := GetDaemonSet(daemonSetName)
+
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+
+			daemonSetNameOVS := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			}
+			ds = GetDaemonSet(daemonSetNameOVS)
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].ReadinessProbe).ShouldNot(BeNil())
+		})
+
 		When("OVNDBCluster instances are available without networkAttachments", func() {
 			var scriptsCM types.NamespacedName
 			var dbs []types.NamespacedName
@@ -329,6 +367,42 @@ var _ = Describe("OVNController controller", func() {
 				"NetworkAttachments error occurred "+
 					"not all pods have interfaces with ips as configured in NetworkAttachments: internalapi",
 			)
+		})
+		It("should have a liveness probe configured", func() {
+
+			daemonSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			}
+			ds := GetDaemonSet(daemonSetName)
+
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+
+			daemonSetNameOVS := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			}
+			ds = GetDaemonSet(daemonSetNameOVS)
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].LivenessProbe).ShouldNot(BeNil())
+		})
+		It("should have a readiness probe configured", func() {
+
+			daemonSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			}
+			ds := GetDaemonSet(daemonSetName)
+
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+
+			daemonSetNameOVS := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			}
+			ds = GetDaemonSet(daemonSetNameOVS)
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].ReadinessProbe).ShouldNot(BeNil())
 		})
 		It("reports that an IP is missing", func() {
 
@@ -613,6 +687,42 @@ var _ = Describe("OVNController controller", func() {
 
 			}, timeout, interval).Should(Succeed())
 		})
+		It("should have a liveness probe configured", func() {
+
+			daemonSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			}
+			ds := GetDaemonSet(daemonSetName)
+
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+
+			daemonSetNameOVS := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			}
+			ds = GetDaemonSet(daemonSetNameOVS)
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].LivenessProbe).ShouldNot(BeNil())
+		})
+		It("should have a readiness probe configured", func() {
+
+			daemonSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			}
+			ds := GetDaemonSet(daemonSetName)
+
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+
+			daemonSetNameOVS := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			}
+			ds = GetDaemonSet(daemonSetNameOVS)
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].ReadinessProbe).ShouldNot(BeNil())
+		})
 	})
 
 	When("OVNController is created with networkAttachment and nic configs", func() {
@@ -644,8 +754,14 @@ var _ = Describe("OVNController controller", func() {
 
 			ds := GetDaemonSet(daemonSetName)
 			Expect(ds.Spec.Template.ObjectMeta.Annotations).To(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
 
 			ds = GetDaemonSet(daemonSetNameOVS)
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].LivenessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].ReadinessProbe).ShouldNot(BeNil())
 			expectedAnnotation, err := json.Marshal(
 				[]networkv1.NetworkSelectionElement{
 					{
@@ -684,6 +800,42 @@ var _ = Describe("OVNController controller", func() {
 			Expect(ovnController.Spec.ExternalIDS.OvnEncapType).To(Equal("geneve"))
 			Expect(ovnController.Spec.ExternalIDS.OvnBridge).To(Equal("br-int"))
 			Expect(ovnController.Spec.ExternalIDS.SystemID).To(Equal("random"))
+		})
+		It("should have a liveness probe configured", func() {
+
+			daemonSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			}
+			ds := GetDaemonSet(daemonSetName)
+
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+
+			daemonSetNameOVS := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			}
+			ds = GetDaemonSet(daemonSetNameOVS)
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].LivenessProbe).ShouldNot(BeNil())
+		})
+		It("should have a readiness probe configured", func() {
+
+			daemonSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			}
+			ds := GetDaemonSet(daemonSetName)
+
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+
+			daemonSetNameOVS := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			}
+			ds = GetDaemonSet(daemonSetNameOVS)
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[1].ReadinessProbe).ShouldNot(BeNil())
 		})
 	})
 
@@ -762,7 +914,11 @@ var _ = Describe("OVNController controller", func() {
 
 			SimulateDaemonsetNumberReady(daemonSetNameOVS)
 
-			ds := GetDaemonSet(daemonSetNameOVS)
+			ds := GetDaemonSet(daemonSetName)
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+
+			ds = GetDaemonSet(daemonSetNameOVS)
 
 			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(2))
@@ -793,6 +949,10 @@ var _ = Describe("OVNController controller", func() {
 			SimulateDaemonsetNumberReady(daemonSetNameOVS)
 
 			ds := GetDaemonSet(daemonSetName)
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).ShouldNot(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).ShouldNot(BeNil())
+
+			ds = GetDaemonSet(daemonSetName)
 
 			//  check TLS volumes
 			th.AssertVolumeExists(CABundleSecretName, ds.Spec.Template.Spec.Volumes)

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -218,6 +218,9 @@ metadata:
   generateName: ovn-controller-
 status:
   phase: Running
+  containerStatuses:
+    - name: ovn-controller
+      ready: true
 ---
 apiVersion: v1
 kind: Pod
@@ -229,6 +232,11 @@ metadata:
   generateName: ovn-controller-ovs-
 status:
   phase: Running
+  containerStatuses:
+    - name: ovs-vswitchd
+      ready: true
+    - name: ovsdb-server
+      ready: true
 ---
 apiVersion: v1
 kind: Service

--- a/tests/kuttl/tests/ovn_liveness/01-assert.yaml
+++ b/tests/kuttl/tests/ovn_liveness/01-assert.yaml
@@ -1,0 +1,1 @@
+../../common/assert_sample_deployment.yaml

--- a/tests/kuttl/tests/ovn_liveness/01-deploy-ovn.yaml
+++ b/tests/kuttl/tests/ovn_liveness/01-deploy-ovn.yaml
@@ -1,0 +1,1 @@
+../../common/deploy_ovn.yaml

--- a/tests/kuttl/tests/ovn_liveness/02-assert.yaml
+++ b/tests/kuttl/tests/ovn_liveness/02-assert.yaml
@@ -1,0 +1,14 @@
+#
+# Check for:
+#
+# - LivenessProbe failure in ovn-controller should restart it once
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: ovn-controller
+status:
+  containerStatuses:
+    - name: ovn-controller
+      restartCount: 1

--- a/tests/kuttl/tests/ovn_liveness/02-pause-ovn-controller.yaml
+++ b/tests/kuttl/tests/ovn_liveness/02-pause-ovn-controller.yaml
@@ -1,0 +1,12 @@
+#
+# Step for:
+#
+# - Force one of the liveness checks to return fail in order to restart
+# ovn-controller
+#
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      controller_pod=$(oc get pod -n $NAMESPACE -l service=ovn-controller -o name|head -1)
+      oc rsh -n $NAMESPACE ${controller_pod} ovn-appctl -t ovn-controller debug/pause

--- a/tests/kuttl/tests/ovn_liveness/05-cleanup-ovn.yaml
+++ b/tests/kuttl/tests/ovn_liveness/05-cleanup-ovn.yaml
@@ -1,0 +1,1 @@
+../../common/cleanup-ovn.yaml

--- a/tests/kuttl/tests/ovn_liveness/05-errors.yaml
+++ b/tests/kuttl/tests/ovn_liveness/05-errors.yaml
@@ -1,0 +1,1 @@
+../../common/errors_cleanup_ovn.yaml

--- a/tests/kuttl/tests/ovn_readiness/01-assert.yaml
+++ b/tests/kuttl/tests/ovn_readiness/01-assert.yaml
@@ -1,0 +1,1 @@
+../../common/assert_sample_deployment.yaml

--- a/tests/kuttl/tests/ovn_readiness/01-deploy-ovn.yaml
+++ b/tests/kuttl/tests/ovn_readiness/01-deploy-ovn.yaml
@@ -1,0 +1,1 @@
+../../common/deploy_ovn.yaml

--- a/tests/kuttl/tests/ovn_readiness/02-assert.yaml
+++ b/tests/kuttl/tests/ovn_readiness/02-assert.yaml
@@ -1,0 +1,24 @@
+#
+# Check for:
+#
+# - ovn-controller status ready is false
+# - ovn-controller connection-status is 'not connected'
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: ovn-controller
+status:
+  containerStatuses:
+    - name: ovn-controller
+      ready: false
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+commands:
+    - script: |
+        controller_pod=$(oc get pod -n $NAMESPACE -l service=ovn-controller -o name|head -1)
+        oc rsh -n $NAMESPACE ${controller_pod} ovn-appctl -t ovn-controller connection-status | grep -q "not connected" || exit 1
+        exit 0

--- a/tests/kuttl/tests/ovn_readiness/02-configure-ovn-remote.yaml
+++ b/tests/kuttl/tests/ovn_readiness/02-configure-ovn-remote.yaml
@@ -1,0 +1,11 @@
+#
+# Step for:
+#
+# - Configure ovn-remote to invalid address
+#
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+    - script: |
+        controller_pod=$(oc get pod -n $NAMESPACE -l service=ovn-controller -o name|head -1)
+        oc rsh -n $NAMESPACE ${controller_pod} ovs-vsctl set open . external_ids:ovn-remote=tcp:1.2.3.4:6642

--- a/tests/kuttl/tests/ovn_readiness/05-cleanup-ovn.yaml
+++ b/tests/kuttl/tests/ovn_readiness/05-cleanup-ovn.yaml
@@ -1,0 +1,1 @@
+../../common/cleanup-ovn.yaml

--- a/tests/kuttl/tests/ovn_readiness/05-errors.yaml
+++ b/tests/kuttl/tests/ovn_readiness/05-errors.yaml
@@ -1,0 +1,1 @@
+../../common/errors_cleanup_ovn.yaml


### PR DESCRIPTION
Implement liveness and readiness probes to monitor the health of the ovn-controller.

Resolves: [OSPRH-6673](https://issues.redhat.com//browse/OSPRH-6673)