### PR TITLE
Force recreation of ovs db cluster on first replica when protocol changes

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -19,7 +19,7 @@ kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-ovn
 namespace: openstack
-timeout: 360
+timeout: 600
 parallel: 1
 suppress:
   - events                     # Remove spammy event logs

--- a/pkg/ovndbcluster/statefulset.go
+++ b/pkg/ovndbcluster/statefulset.go
@@ -54,6 +54,13 @@ func StatefulSet(
 		PeriodSeconds:       5,
 		InitialDelaySeconds: 5,
 	}
+	startupProbe := &corev1.Probe{
+		// TODO might need tuning
+		TimeoutSeconds:      5,
+		PeriodSeconds:       3,
+		FailureThreshold:    20,
+		InitialDelaySeconds: 3,
+	}
 
 	var preStopCmd []string
 	cmd := []string{"/usr/bin/dumb-init"}
@@ -67,6 +74,7 @@ func StatefulSet(
 		},
 	}
 	readinessProbe.Exec = livenessProbe.Exec
+	startupProbe.Exec = livenessProbe.Exec
 
 	preStopCmd = []string{
 		"/usr/local/bin/container-scripts/cleanup.sh",
@@ -159,6 +167,7 @@ func StatefulSet(
 							Resources:                instance.Spec.Resources,
 							ReadinessProbe:           readinessProbe,
 							LivenessProbe:            livenessProbe,
+							StartupProbe:             startupProbe,
 							Lifecycle:                lifecycle,
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						},

--- a/tests/kuttl/common/errors_cleanup_ovn.yaml
+++ b/tests/kuttl/common/errors_cleanup_ovn.yaml
@@ -65,14 +65,12 @@ kind: Pod
 metadata:
   labels:
     service: ovsdbserver-nb
-  name: ovsdbserver-nb-0
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   labels:
     service: ovsdbserver-sb
-  name: ovsdbserver-sb-0
 ---
 apiVersion: v1
 kind: Pod
@@ -97,27 +95,9 @@ kind: Service
 metadata:
   labels:
     service: ovsdbserver-nb
-  name: ovsdbserver-nb
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    service: ovsdbserver-nb
-    statefulset.kubernetes.io/pod-name: ovsdbserver-nb-0
-  name: ovsdbserver-nb-0
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     service: ovsdbserver-sb
-  name: ovsdbserver-sb
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    service: ovsdbserver-sb
-    statefulset.kubernetes.io/pod-name: ovsdbserver-sb-0
-  name: ovsdbserver-sb-0

--- a/tests/kuttl/common/scripts/check_cluster_status.sh
+++ b/tests/kuttl/common/scripts/check_cluster_status.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-# arguments: db-type: {nb, sb}, num-pods
+# arguments: db-type: {nb, sb}, num-pods, ssl/tcp
 # Check arguments
 if [ $# -lt 2 ]; then
-    echo "Usage: $0 <db-type> <num-pods>"
+    echo "Usage: $0 <db-type> <num-pods> [ssl]"
     exit 1
 fi
 
 DB_TYPE="$1"
 NUM_PODS="$2"
+PROTOCOL="${3:-tcp}"
 POD_PREFIX="ovsdbserver-${DB_TYPE}"
 CTL_FILE="ovn${DB_TYPE}_db.ctl"
 if [ "$DB_TYPE" == "nb" ]; then
@@ -46,7 +47,7 @@ for pod in "${pods[@]}"; do
     # check if the pod is connected with all other pods
     for server in "${pods[@]}"; do
     echo "Checking if $server is mentioned in the output"
-    if ! echo "$output" | grep -q "$server"; then
+    if ! echo "$output" | grep -q "$PROTOCOL:$server"; then
         exit 1
     fi
     done

--- a/tests/kuttl/tests/ovn_db_delete/03-assert.yaml
+++ b/tests/kuttl/tests/ovn_db_delete/03-assert.yaml
@@ -3,7 +3,5 @@ kind: TestAssert
 commands:
   - script: |
       $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh nb 3
-      test $? -eq 0
   - script: |
       $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh sb 3
-      test $? -eq 0

--- a/tests/kuttl/tests/ovn_db_delete/09-assert.yaml
+++ b/tests/kuttl/tests/ovn_db_delete/09-assert.yaml
@@ -3,7 +3,5 @@ kind: TestAssert
 commands:
   - script: |
       $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh nb 1
-      test $? -eq 0
   - script: |
       $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh sb 1
-      test $? -eq 0

--- a/tests/kuttl/tests/ovn_tls_enable/00-assert.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/00-assert.yaml
@@ -1,0 +1,1 @@
+../../common/assert_tls_certs.yaml

--- a/tests/kuttl/tests/ovn_tls_enable/00-tls_ca_bundle.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/00-tls_ca_bundle.yaml
@@ -1,0 +1,1 @@
+../../common/tls_ca_bundle.yaml

--- a/tests/kuttl/tests/ovn_tls_enable/00-tls_certs.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/00-tls_certs.yaml
@@ -1,0 +1,1 @@
+../../common/tls_certs.yaml

--- a/tests/kuttl/tests/ovn_tls_enable/01-assert.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/01-assert.yaml
@@ -1,0 +1,39 @@
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNDBCluster
+metadata:
+  name: ovndbcluster-nb-sample
+spec:
+  replicas: 3
+status:
+  readyCount: 3
+---
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNDBCluster
+metadata:
+  name: ovndbcluster-sb-sample
+spec:
+  replicas: 3
+status:
+  readyCount: 3
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  # check the DB uri scheme is tcp
+  - script: |
+      template='{{.status.internalDbAddress}}{{"\n"}}'
+      regex="tcp:.*"
+      dbUri=$(oc get -n $NAMESPACE OVNDBCluster ovndbcluster-sb-sample -o go-template="$template")
+      matches=$(echo "$dbUri" | sed -e "s?$regex??")
+      if [[ -n "$matches" ]]; then
+        exit 1
+      fi
+  # Check ovn connect is ptcp
+  - script: |
+      sb_pod=$(oc get pod -n $NAMESPACE -l service=ovsdbserver-sb -o name|head -1)
+      oc rsh -n $NAMESPACE ${sb_pod} ovn-sbctl --no-leader-only  get-connection | grep -q ptcp
+  # Check we have 3 servers using tcp
+  - script: |
+      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh nb 3
+  - script: |
+      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh sb 3

--- a/tests/kuttl/tests/ovn_tls_enable/01-deploy-ovn.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/01-deploy-ovn.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      cp ../../../../config/samples/ovn_* deploy/
+      oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/ovn_tls_enable/02-assert.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/02-assert.yaml
@@ -1,0 +1,39 @@
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNDBCluster
+metadata:
+  name: ovndbcluster-nb-sample
+spec:
+  replicas: 3
+status:
+  readyCount: 3
+---
+apiVersion: ovn.openstack.org/v1beta1
+kind: OVNDBCluster
+metadata:
+  name: ovndbcluster-sb-sample
+spec:
+  replicas: 3
+status:
+  readyCount: 3
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  # check the DB uri scheme is ssl
+  - script: |
+      template='{{.status.internalDbAddress}}{{"\n"}}'
+      regex="ssl:.*"
+      dbUri=$(oc get -n $NAMESPACE OVNDBCluster ovndbcluster-sb-sample -o go-template="$template")
+      matches=$(echo "$dbUri" | sed -e "s?$regex??")
+      if [[ -n "$matches" ]]; then
+        exit 1
+      fi
+  # Check ovn connect is pssl
+  - script: |
+      sb_pod=$(oc get pod -n $NAMESPACE -l service=ovsdbserver-sb -o name|head -1)
+      oc rsh -n $NAMESPACE ${sb_pod} ovn-sbctl --no-leader-only  get-connection | grep -q pssl
+  # Check we have 3 servers using ssl
+  - script: |
+      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh nb 3 ssl
+  - script: |
+      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh sb 3 ssl

--- a/tests/kuttl/tests/ovn_tls_enable/02-enable-tls.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/02-enable-tls.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      cp ../../../../config/samples/ovn_* enable_tls/
+      oc kustomize enable_tls | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/ovn_tls_enable/03-cleanup.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/03-cleanup.yaml
@@ -1,0 +1,1 @@
+../../common/cleanup-ovn.yaml

--- a/tests/kuttl/tests/ovn_tls_enable/03-errors.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/03-errors.yaml
@@ -1,0 +1,1 @@
+../../common/errors_cleanup_ovn.yaml

--- a/tests/kuttl/tests/ovn_tls_enable/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/deploy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ovn_v1beta1_ovndbcluster.yaml
+patches:
+- patch: |-
+    - op: add
+      path: /spec/replicas
+      value: 3
+  target:
+    kind: OVNDBCluster

--- a/tests/kuttl/tests/ovn_tls_enable/enable_tls/kustomization.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/enable_tls/kustomization.yaml
@@ -1,0 +1,47 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ovn_v1beta1_ovnnorthd.yaml
+- ovn_v1beta1_ovndbcluster.yaml
+- ovn_v1beta1_ovncontroller.yaml
+patches:
+- patch: |-
+    - op: add
+      path: /spec/replicas
+      value: 3
+  target:
+    kind: OVNDBCluster
+- patch: |-
+    - op: add
+      path: /spec/tls
+      value:
+        caBundleSecretName: combined-ca-bundle
+        secretName: cert-ovsdbserver-nb-svc
+  target:
+    kind: OVNDBCluster
+    name: ovndbcluster-nb-sample
+- patch: |-
+    - op: add
+      path: /spec/tls
+      value:
+        caBundleSecretName: combined-ca-bundle
+        secretName: cert-ovsdbserver-sb-svc
+  target:
+    kind: OVNDBCluster
+    name: ovndbcluster-sb-sample
+- patch: |-
+    - op: add
+      path: /spec/tls
+      value:
+        caBundleSecretName: combined-ca-bundle
+        secretName: cert-ovnnorthd-svc
+  target:
+    kind: OVNNorthd
+- patch: |-
+    - op: add
+      path: /spec/tls
+      value:
+        caBundleSecretName: combined-ca-bundle
+        secretName: cert-ovncontroller-svc
+  target:
+    kind: OVNController


### PR DESCRIPTION
Cannot remove final cluster member to change protocol, but can convert to standalone schema. Cluster gets recreated with the correct address.

Jira: [OSPRH-6954](https://issues.redhat.com//browse/OSPRH-6954)
Jira: [OSPRH-10415](https://issues.redhat.com//browse/OSPRH-10415)