### PR TITLE
Restart ovn-controller gracefully on PreStop

### DIFF
--- a/pkg/ovncontroller/daemonset.go
+++ b/pkg/ovncontroller/daemonset.go
@@ -75,7 +75,7 @@ func CreateOVNDaemonSet(
 			Lifecycle: &corev1.Lifecycle{
 				PreStop: &corev1.LifecycleHandler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"/usr/share/ovn/scripts/ovn-ctl", "stop_controller"},
+						Command: []string{"/usr/local/bin/container-scripts/stop-ovn-controller.sh"},
 					},
 				},
 			},

--- a/templates/ovncontroller/bin/functions
+++ b/templates/ovncontroller/bin/functions
@@ -27,6 +27,14 @@ ovs_dir=/var/lib/openvswitch
 FLOWS_RESTORE_SCRIPT=$ovs_dir/flows-script
 FLOWS_RESTORE_DIR=$ovs_dir/saved-flows
 SAFE_TO_STOP_OVSDB_SERVER_SEMAPHORE=$ovs_dir/is_safe_to_stop_ovsdb_server
+OVN_CONTROLLER_CLEANUP_CHASSIS_FLAG=$ovs_dir/cleanup_chassis
+
+function ovn_controller_is_restarting() {
+    if [ ! -f $OVN_CONTROLLER_CLEANUP_CHASSIS_FLAG ]; then
+        return 0
+    fi
+    return 1
+}
 
 function cleanup_ovsdb_server_semaphore() {
     rm -f $SAFE_TO_STOP_OVSDB_SERVER_SEMAPHORE 2>&1 > /dev/null
@@ -54,6 +62,7 @@ function configure_external_ids {
     ovs-vsctl set open . external-ids:ovn-bridge=${OVNBridge}
     ovs-vsctl set open . external-ids:ovn-remote=${OVNRemote}
     ovs-vsctl set open . external-ids:ovn-encap-type=${OVNEncapType}
+    ovs-vsctl set open . external-ids:ovn-ofctrl-wait-before-clear="8000"
     if [ -n "$OVNHostName" ]; then
         ovs-vsctl set open . external-ids:hostname=${OVNHostName}
     fi

--- a/templates/ovncontroller/bin/stop-ovn-controller.sh
+++ b/templates/ovncontroller/bin/stop-ovn-controller.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -ex
+source $(dirname $0)/functions
+
+OPTS=
+if ovn_controller_is_restarting; then
+    OPTS+="--restart"
+fi
+
+/usr/share/ovn/scripts/ovn-ctl stop_controller $OPTS


### PR DESCRIPTION
Otherwise, it will clean up chassis and other relevant records and cause unnecessary router failovers.

--

This is not a complete solution: the operator will have to indicate to ovn-controller when it's actually ok to clean the chassis records up, with the file created in the container. (Note: I am not sure this is the best way to reflect this request into the pod. Perhaps the pod should instead talk to k8s where this information could be exposed. Another alternative is storing this information somewhere in OVSDB - maybe ovn-controller could even be expanded to read the flag from there and do the right thing?)


Related-Issue: [OSPRH-10821](https://issues.redhat.com//browse/OSPRH-10821)