### PR TITLE
Use dns cluster info from lib common get function

### DIFF
--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -40,10 +40,6 @@ const (
 	// ServiceClusterType - Constant to identify Cluster services
 	ServiceClusterType = "cluster"
 
-	// DNSSuffix : hardcoded value on how DNSCore domain is configured
-	DNSSuffix = "cluster.local"
-	// TODO: retrieve it from environment
-
 	// Container image fall-back defaults
 
 	// OVNNBContainerImage is the fall-back container image for OVNDBCluster NB

--- a/controllers/ovndbcluster_controller.go
+++ b/controllers/ovndbcluster_controller.go
@@ -40,6 +40,7 @@ import (
 
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
@@ -623,7 +624,9 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 			if svc.Spec.ClusterIP == "None" || svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
 				continue
 			}
-			internalDbAddress = append(internalDbAddress, fmt.Sprintf("%s:%s.%s.svc.%s:%d", scheme, svc.Name, svc.Namespace, ovnv1.DNSSuffix, svcPort))
+			// TODO: Watch operator.openshift.io resource once cluster domain is customizable
+			clusterDomain := clusterdns.GetDNSClusterDomain()
+			internalDbAddress = append(internalDbAddress, fmt.Sprintf("%s:%s.%s.svc.%s:%d", scheme, svc.Name, svc.Namespace, clusterDomain, svcPort))
 		}
 
 		// Note setting this to the singular headless service address (e.g ssl:ovsdbserver-sb...) "works" but will not


### PR DESCRIPTION
Openshift coreDNS creates the domain name using an string located in dnses.operator.openshift.io. This string can change in the future, calling lib-common/GetDNSClusterDomain the responsability of gathering this information correctly only falls under lib-common intead of all operators.

Resolves: [OSPRH-3627](https://issues.redhat.com//browse/OSPRH-3627)
Depends-on: https://github.com/openstack-k8s-operators/lib-common/pull/580