### PR TITLE
[ovsdb-server] Gracefully handle empty db file on startup

### DIFF
--- a/templates/ovncontroller/bin/functions
+++ b/templates/ovncontroller/bin/functions
@@ -22,6 +22,7 @@ OVNAvailabilityZones=${OVNAvailabilityZones:-""}
 EnableChassisAsGateway=${EnableChassisAsGateway:-true}
 PhysicalNetworks=${PhysicalNetworks:-""}
 OVNHostName=${OVNHostName:-""}
+DB_FILE=/etc/openvswitch/conf.db
 
 ovs_dir=/var/lib/openvswitch
 FLOWS_RESTORE_SCRIPT=$ovs_dir/flows-script
@@ -143,4 +144,11 @@ function configure_physical_networks {
         ovs-vsctl --if-exists remove open . external_ids ovn-bridge-mappings
     fi
 
+}
+
+function wait_for_db_creation {
+    while [ ! -s ${DB_FILE} ]; do
+        echo "${DB_FILE} does not exist yet or is empty. Waiting..."
+        sleep 1
+    done
 }

--- a/templates/ovncontroller/bin/init-ovsdb-server.sh
+++ b/templates/ovncontroller/bin/init-ovsdb-server.sh
@@ -15,8 +15,18 @@
 # under the License.
 
 set -ex
+source $(dirname $0)/functions
+trap wait_for_db_creation EXIT
 
+# If db file is empty, remove it; otherwise service won't start.
+# See https://issues.redhat.com/browse/FDP-689 for more details.
+if ! [ -s ${DB_FILE} ]; then
+    rm -f ${DB_FILE}
+fi
 # Initialize or upgrade database if needed
 CTL_ARGS="--system-id=random --no-ovs-vswitchd"
 /usr/share/openvswitch/scripts/ovs-ctl start $CTL_ARGS
 /usr/share/openvswitch/scripts/ovs-ctl stop $CTL_ARGS
+
+wait_for_db_creation
+trap - EXIT

--- a/templates/ovncontroller/bin/start-ovsdb-server.sh
+++ b/templates/ovncontroller/bin/start-ovsdb-server.sh
@@ -21,7 +21,7 @@ source $(dirname $0)/functions
 cleanup_ovsdb_server_semaphore
 
 # Start the service
-ovsdb-server /etc/openvswitch/conf.db \
+ovsdb-server ${DB_FILE} \
     --pidfile \
     --remote=punix:/var/run/openvswitch/db.sock \
     --private-key=db:Open_vSwitch,SSL,private_key \


### PR DESCRIPTION
In some situations, e.g. when ovsdb-server is killed during db file initialization, the file may end up empty. On next restart, the service fails to start because the file format is invalid.

Ideally, ovs start scripts would handle this situation gracefully, as tracked in https://issues.redhat.com/browse/FDP-689.

But in the meantime, we can also handle the situation on operator's side, by removing the empty file if present. Also added trap signals to the initialization script so it waits for db file to be initialized before getting terminated.

Resolves: OSPRH-10688