### PR TITLE
Bump golangci-lint version compatible with go1.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ tidy: ## Run go mod tidy on every mod file in the repo
 
 .PHONY: golangci-lint
 golangci-lint:
-	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.1
 	$(LOCALBIN)/golangci-lint run --fix
 
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)


### PR DESCRIPTION
With incompatible version it fully utilizes system memory and crashes.

Got missed in https://github.com/openstack-k8s-operators/ovn-operator/pull/350. Jira: [OSPRH-6501](https://issues.redhat.com//browse/OSPRH-6501)