### PR TITLE
[kuttl] Use relative path to scripts

### DIFF
--- a/tests/kuttl/tests/ovn_db_delete/03-assert.yaml
+++ b/tests/kuttl/tests/ovn_db_delete/03-assert.yaml
@@ -2,6 +2,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
-      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh nb 3
+      ../../common/scripts/check_cluster_status.sh nb 3
   - script: |
-      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh sb 3
+      ../../common/scripts/check_cluster_status.sh sb 3

--- a/tests/kuttl/tests/ovn_db_delete/09-assert.yaml
+++ b/tests/kuttl/tests/ovn_db_delete/09-assert.yaml
@@ -2,6 +2,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
-      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh nb 1
+      ../../common/scripts/check_cluster_status.sh nb 1
   - script: |
-      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh sb 1
+      ../../common/scripts/check_cluster_status.sh sb 1

--- a/tests/kuttl/tests/ovn_tls_enable/01-assert.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/01-assert.yaml
@@ -34,6 +34,6 @@ commands:
       oc rsh -n $NAMESPACE ${sb_pod} ovn-sbctl --no-leader-only  get-connection | grep -q ptcp
   # Check we have 3 servers using tcp
   - script: |
-      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh nb 3
+      ../../common/scripts/check_cluster_status.sh nb 3
   - script: |
-      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh sb 3
+      ../../common/scripts/check_cluster_status.sh sb 3

--- a/tests/kuttl/tests/ovn_tls_enable/02-assert.yaml
+++ b/tests/kuttl/tests/ovn_tls_enable/02-assert.yaml
@@ -34,6 +34,6 @@ commands:
       oc rsh -n $NAMESPACE ${sb_pod} ovn-sbctl --no-leader-only  get-connection | grep -q pssl
   # Check we have 3 servers using ssl
   - script: |
-      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh nb 3 ssl
+      ../../common/scripts/check_cluster_status.sh nb 3 ssl
   - script: |
-      $OVN_KUTTL_DIR/../common/scripts/check_cluster_status.sh sb 3 ssl
+      ../../common/scripts/check_cluster_status.sh sb 3 ssl


### PR DESCRIPTION
Couple of tests were relying on OVN_KUTTL_DIR to
be set, let's avoid the dep on extra var and use relative path to the test.

Alternative to https://github.com/openstack-k8s-operators/install_yamls/pull/915