### PR TITLE
[OSPRH-13960] Fix OVNController CR condition initialization

### DIFF
--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -155,11 +155,6 @@ func (r *OVNControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}()
 
-	// If we're not deleting this and the service object doesn't have our finalizer, add it.
-	if instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer()) || isNewInstance {
-		return ctrl.Result{}, nil
-	}
-
 	// initialize conditions used later as Status=Unknown
 	cl := condition.CreateList(
 		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
@@ -174,6 +169,11 @@ func (r *OVNControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	instance.Status.Conditions.Init(&cl)
 	instance.Status.ObservedGeneration = instance.Generation
+
+	// If we're not deleting this and the service object doesn't have our finalizer, add it.
+	if instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer()) || isNewInstance {
+		return ctrl.Result{}, nil
+	}
 
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}


### PR DESCRIPTION
Please see [1] for details.  The same problem identified there for the `OpenStack` CR also affects the `OVNController` CR in this operator within its respective reconcile loop.

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/1294#issue-2845602087