### PR TITLE
Do not use MustParse to process PVC size

### DIFF
--- a/controllers/ovndbcluster_controller.go
+++ b/controllers/ovndbcluster_controller.go
@@ -578,12 +578,13 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 		return ctrl.Result{}, fmt.Errorf("waiting for Topology requirements: %w", err)
 	}
 
+	stsSpec, err := ovndbcluster.StatefulSet(instance, inputHash,
+		serviceLabels, serviceAnnotations, topology)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	// Define a new Statefulset object
-	sfset := statefulset.NewStatefulSet(
-		ovndbcluster.StatefulSet(instance, inputHash, serviceLabels, serviceAnnotations, topology),
-		time.Duration(5)*time.Second,
-	)
-
+	sfset := statefulset.NewStatefulSet(stsSpec, time.Duration(5)*time.Second)
 	ctrlResult, err = sfset.CreateOrPatch(ctx, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(


### PR DESCRIPTION
The `resource.MustParse` function was previously used by the operator to process the `storageSize` request provided by the top-level CR. However, even though `defer()` and `recover()` can be used to handle the `panic()` generated by a wrong user input, that approach doesn't seem to work properly and the operator crashes without any chance to recover. The `.ParseQuantity` implementation returns an error instead of `panic()`, and it can be easily caught at the operator level. This change moves away from the `MustParse` usage and relies on the `ParseQuantity` mechanism.