### PR TITLE
Improve error handling

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,5 +7,14 @@ linters:
     - ginkgolinter
     - gofmt
     - govet
+    - gosec
+    - errname
+    - err113
 run:
   timeout: 5m
+
+issues:
+  exclude-rules:
+    - path: '(.+)_test\.go'
+      linters:
+        - gosec

--- a/controllers/ovn_common.go
+++ b/controllers/ovn_common.go
@@ -28,7 +28,7 @@ import (
 // fields to index to reconcile when changed
 const (
 	tlsField                = ".spec.tls.secretName"
-	caBundleSecretNameField = ".spec.tls.caBundleSecretName"
+	caBundleSecretNameField = ".spec.tls.caBundleSecretName" // #nosec
 	topologyField           = ".spec.topologyRef.Name"
 )
 

--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -640,7 +640,7 @@ func (r *OVNControllerReconciler) reconcileNormal(ctx context.Context, instance 
 
 	instance.Status.NetworkAttachments = networkAttachmentStatus
 	if !networkReady {
-		err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachment)
+		err := fmt.Errorf("%w with ips as configured in NetworkAttachments: %s", util.ErrPodsInterfaces, instance.Spec.NetworkAttachment)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.NetworkAttachmentsReadyCondition,
 			condition.ErrorReason,

--- a/controllers/ovndbcluster_controller.go
+++ b/controllers/ovndbcluster_controller.go
@@ -614,7 +614,7 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 	if networkReady {
 		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 	} else {
-		err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachment)
+		err := fmt.Errorf("%w with ips as configured in NetworkAttachments: %s", util.ErrPodsInterfaces, instance.Spec.NetworkAttachment)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.NetworkAttachmentsReadyCondition,
 			condition.ErrorReason,
@@ -718,7 +718,7 @@ func getPodIPInNetwork(ovnPod corev1.Pod, namespace string, networkAttachment st
 		}
 	}
 	// If this is reached it means that no IP was found, construct error and return
-	err = fmt.Errorf("error while getting IP address from pod %s in network %s, IP is empty", ovnPod.Name, networkAttachment)
+	err = fmt.Errorf("%w IP address from pod %s in network %s, IP is empty", util.ErrInvalidStatus, ovnPod.Name, networkAttachment)
 	return "", err
 }
 


### PR DESCRIPTION
Follow best practices for secure error and exception handling.

Add err113 and gosec check in golang-ci-linter.
Errors in neutron controller have been moved to a central file.
Resolve: https://issues.redhat.com/browse/OSPRH-9009