### PR TITLE
Propogate invalid nic mapping error to ovncontroller status

### DIFF
--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -489,6 +489,12 @@ func (r *OVNControllerReconciler) reconcileNormal(ctx context.Context, instance 
 	networkAttachments, err := ovncontroller.CreateOrUpdateAdditionalNetworks(ctx, helper, instance, ovsServiceLabels)
 	if err != nil {
 		Log.Info(fmt.Sprintf("Failed to create additional networks: %s", err))
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.NetworkAttachmentsReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.NetworkAttachmentsReadyErrorMessage,
+			err.Error()))
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Set condition when adding nic mappings fails and also added functional test for it.

Resolves: [OSPRH-8514](https://issues.redhat.com//browse/OSPRH-8514)