### PR TITLE
Allow ovs-vswitchd logging by separating flow restoration

### DIFF
--- a/templates/ovncontroller/bin/start-vswitchd.sh
+++ b/templates/ovncontroller/bin/start-vswitchd.sh
@@ -30,7 +30,10 @@ ovs-vsctl --no-wait set open_vswitch . other_config:flow-restore-wait=true
 
 # It's safe to start vswitchd now. Do it.
 # --detach to allow the execution to continue to restoring the flows.
-/usr/sbin/ovs-vswitchd --pidfile --mlockall --detach
+# We need to use --log-file since --detach disables all logging explicitly.
+# Once https://issues.redhat.com/browse/FDP-1292 is fixed we will be able to
+# use system logs only.
+/usr/sbin/ovs-vswitchd --pidfile --mlockall --detach --log-file
 
 # Restore saved flows.
 if [ -f $FLOWS_RESTORE_SCRIPT ]; then
@@ -51,4 +54,4 @@ ovs-vsctl remove open_vswitch . other_config flow-restore-wait
 
 # This is container command script. Block it from exiting, otherwise k8s will
 # restart the container again.
-sleep infinity
+tail -f /var/log/openvswitch/ovs-vswitchd.log


### PR DESCRIPTION
We used --detach on ovs-vswitchd execution to allow for flow
restoration, but this had the side effect of not having its console logs
available. In order to get those back, we use --log-file and then tail
that file in the end of the script to be able to see these logs from the
oc log command.

Jira: [OSPRH-11228](https://issues.redhat.com//browse/OSPRH-11228)