### PR TITLE
[ovn-controller] Change startup mechanism of ovs pods

### DIFF
--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -612,7 +612,6 @@ func (r *OVNControllerReconciler) reconcileNormal(ctx context.Context, instance 
 	instance.Status.DesiredNumberScheduled = dset.GetDaemonSet().Status.DesiredNumberScheduled
 	instance.Status.NumberReady = dset.GetDaemonSet().Status.NumberReady
 
-	// Define a new DaemonSet object for OVS (ovsdb-server + ovs-vswitchd)
 	ovsdset := daemonset.NewDaemonSet(
 		ovncontroller.CreateOVSDaemonSet(instance, inputHash, ovsServiceLabels, serviceAnnotations, topology),
 		time.Duration(5)*time.Second,
@@ -743,6 +742,11 @@ func (r *OVNControllerReconciler) generateServiceConfigMaps(
 		templateParameters["OVNEncapNIC"] = nad.GetNetworkIFName(instance.Spec.NetworkAttachment)
 	} else {
 		templateParameters["OVNEncapNIC"] = "eth0"
+	}
+	if instance.Spec.TLS.Enabled() {
+		templateParameters["TLS"] = "Enabled"
+	} else {
+		templateParameters["TLS"] = "Disabled"
 	}
 	cms := []util.Template{
 		// ScriptsConfigMap

--- a/templates/ovncontroller/bin/init-ovsdb-server.sh
+++ b/templates/ovncontroller/bin/init-ovsdb-server.sh
@@ -18,15 +18,71 @@ set -ex
 source $(dirname $0)/functions
 trap wait_for_db_creation EXIT
 
+function init_ovsdb_server {
+    # Initialize or upgrade database if needed
+    CTL_ARGS="--system-id=random --no-ovs-vswitchd"
+    /usr/share/openvswitch/scripts/ovs-ctl start $CTL_ARGS
+    /usr/share/openvswitch/scripts/ovs-ctl stop $CTL_ARGS
+
+    if [ ! -f /var/lib/openvswitch/already_executed ]; then
+        # If file was not present, set status INIT
+        echo "INIT" > /var/lib/openvswitch/already_executed
+    fi
+
+    wait_for_db_creation
+    trap - EXIT
+}
+
 # If db file is empty, remove it; otherwise service won't start.
 # See https://issues.redhat.com/browse/FDP-689 for more details.
 if ! [ -s ${DB_FILE} ]; then
     rm -f ${DB_FILE}
 fi
-# Initialize or upgrade database if needed
-CTL_ARGS="--system-id=random --no-ovs-vswitchd"
-/usr/share/openvswitch/scripts/ovs-ctl start $CTL_ARGS
-/usr/share/openvswitch/scripts/ovs-ctl stop $CTL_ARGS
 
-wait_for_db_creation
-trap - EXIT
+# Check if file is created, if not means it's first execution
+if [ -f /var/lib/openvswitch/already_executed ]; then
+    if [ {{ .TLS }} == "Enabled" ]; then
+        # TLS is used
+        TLSOptions="--certificate=/etc/pki/tls/certs/ovndb.crt --private-key=/etc/pki/tls/private/ovndb.key --ca-cert=/etc/pki/tls/certs/ovndbca.crt"
+        DBOptions="--db ssl:ovsdbserver-nb.openstack.svc.cluster.local:6641"
+    else
+        # Normal TCP is used
+        TLSOptions=""
+        DBOptions="--db tcp:ovsdbserver-nb.openstack.svc.cluster.local:6641"
+    fi
+
+    # Need to double check that ovsdb-server and vswitchd are actually running
+    # (That pod was not unhealty and it got destroyed)
+    # In the following steps we need ovsdb-server to be running, check pid file
+    if [ ! -f /run/openvswitch/ovsdb-server.pid ]; then
+        # No PID file, start as normal
+        echo "No PID file found, init ovsdb_server as it's the only pod"
+        init_ovsdb_server
+        exit 0
+    fi
+    # File is created, no need to run ovs-ctl
+    # Change state to "UPDATE"
+    echo "UPDATE" > /var/lib/openvswitch/already_executed
+    # Clear possible leftovers of past executions
+    ## Need to lower chassis priority
+    # First get the system-id
+    chassis_id=$(ovs-vsctl get Open_Vswitch . external_ids:system-id)
+    nb_output=$(ovn-nbctl --no-leader-only $DBOptions $TLSOptions --columns=_uuid,priority find Gateway_Chassis chassis_name=$chassis_id)
+    # Check that nbctl was executed correctly
+    if [ $? -ne 0 ]; then
+        echo "ERROR: ovn-nbctl find command failed"
+        exit 1
+    fi
+    row_uuid=$(echo "$nb_output" | grep "_uuid" | cut -d':' -f2 | xargs)
+    priority=$(echo "$nb_output" | grep "priority" | cut -d':' -f2 | xargs)
+    # Save priority to be able to restore it later (It's overwritting, not appending, hence no check)
+    echo $priority > /var/lib/openvswitch/old_priority
+    # Set lower priority (lowest value possible 0)
+    ovn-nbctl --no-leader-only $DBOptions $TLSOptions set Gateway_Chassis $row_uuid priority=0
+    # Check that nbctl was executed correctly
+    if [ $? -ne 0 ]; then
+        echo "ERROR: ovn-nbctl set command failed"
+        exit 1
+    fi
+    exit 0
+fi

--- a/templates/ovncontroller/bin/start-vswitchd.sh
+++ b/templates/ovncontroller/bin/start-vswitchd.sh
@@ -14,6 +14,33 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# Check which connection is used
+if [ {{ .TLS }} == "Enabled" ]; then
+    # TLS is used
+    TLSOptions="--certificate=/etc/pki/tls/certs/ovndb.crt --private-key=/etc/pki/tls/private/ovndb.key --ca-cert=/etc/pki/tls/certs/ovndbca.crt"
+    DBOptions="--db ssl:ovsdbserver-nb.openstack.svc.cluster.local:6641"
+else
+    # Normal TCP is used
+    TLSOptions=""
+    DBOptions="--db tcp:ovsdbserver-nb.openstack.svc.cluster.local:6641"
+fi
+
+
+# Check if we're doing an update
+echo "Check if we're doing an update"
+if [ -f /var/lib/openvswitch/already_executed ]; then
+    while true; do
+        if [ $(cat /var/lib/openvswitch/already_executed) == "OVSDB_SERVER" ]; then
+            break
+        fi
+        if [ $(cat /var/lib/openvswitch/already_executed) == "INIT" ]; then
+            break
+        fi
+        sleep 0.1
+    done
+    echo "OVSDBSERVER Already up, start script"
+fi
+
 source $(dirname $0)/functions
 wait_for_ovsdb_server
 
@@ -30,7 +57,7 @@ ovs-vsctl --no-wait set open_vswitch . other_config:flow-restore-wait=true
 
 # It's safe to start vswitchd now. Do it.
 # --detach to allow the execution to continue to restoring the flows.
-/usr/sbin/ovs-vswitchd --pidfile --mlockall --detach
+/usr/sbin/ovs-vswitchd --pidfile --overwrite-pidfile --mlockall --detach
 
 # Restore saved flows.
 if [ -f $FLOWS_RESTORE_SCRIPT ]; then
@@ -48,6 +75,30 @@ cleanup_flows_backup
 
 # Now, inform vswitchd that we are done.
 ovs-vsctl remove open_vswitch . other_config flow-restore-wait
+
+# Restore the priority if this was changed during the update
+if [ -f /var/lib/openvswitch/old_priority ]; then
+    echo "Using DBOptions: $DBOptions"
+    echo "Using TLSOptions: $TLSOptions"
+    priority=$(cat /var/lib/openvswitch/old_priority)
+    echo "Restoring old priority, which was: $priority"
+    chassis_id=$(ovs-vsctl get Open_Vswitch . external_ids:system-id)
+    nb_output=$(ovn-nbctl --no-leader-only $DBOptions $TLSOptions --columns=_uuid,priority find Gateway_Chassis chassis_name=$chassis_id)
+    err=$?
+    if [ $err -ne 0 ]; then
+        echo "Error while getting gateway chassis uuid $err"
+    fi
+    row_uuid=$(echo "$nb_output" | grep "_uuid" | cut -d':' -f2 | xargs)
+    rm /var/lib/openvswitch/old_priority
+    ovn-nbctl --no-leader-only $DBOptions $TLSOptions set Gateway_Chassis $row_uuid priority=$priority
+    err=$?
+    if [ $err -ne 0 ]; then
+        echo "Error while setting gateway chassis priority ($priority), error: $err"
+    fi
+fi
+
+# Set state to "RUNNING"
+echo "RUNNING" > /var/lib/openvswitch/already_executed
 
 # This is container command script. Block it from exiting, otherwise k8s will
 # restart the container again.


### PR DESCRIPTION
This commit aims to modify the starting scripts of the ovn-controller-ovs daemonset.

This is done to allow modifying the RollingUpdate Strategy to not allow any Unavailable pod during update, what this will cause is that during an update to the pod (delete old one and create new one) instead of first deleting the first one and then deleting the next one, it will create the new pod while the old one is running. Due to how the startup scritps works currently this is not allowed.

The reason behind this is to try to lower the downtime observed if the environment is using centralized floating ip during an update.

With this commit the ovn-controller-ovs will share the PID namespace with the host, in order to allow signaling between old/new pod.

Another change is adding an STATE that the containers (ovsdb-server, ovs-vswitchd and ovsdb-server-init) will handle internally.

The differents states are:
 - NULL (No file): will happen the fist time ds is created on the oc worker.
 - INIT: First time init-ovsdb-server is executed on the oc worker.
 - OVSDB_SERVER: once ovsdb-server pod has run the startup script
 - RUNNING: Once ovsdb-server is up  and ovs-vswitchd has run the startup script.
 - UPDATE: Once a new pod is created and ovsdb-server-init has run.
 - RESTART_VSWITCH: After ovsdb-server-init has finished, new ovsdb-server pod has stopped the old ovs-vswitchd process.
 - RESTART_DBSERVER: After old ovs-vswitchd has been restarted the old ovsdb-server is also stop.

The normal flow of states is the following:

NULL -> INIT -> OVSDB_SERVER -> RUNNING

Scale down: If the oc worker is deleted the DS and all the pods and mount points will be deleted, in case of node being up again it should start from NULL

Update: RUNNING -> (Change on CR) -> UPDATE -> RESTART_VSWITCHD ->
RESTART_DBSERVER -> OVSDB_SERVER -> RUNNING

Related: [OSPRH-11636](https://issues.redhat.com//browse/OSPRH-11636)
Jira: [OSPRH-10821](https://issues.redhat.com//browse/OSPRH-10821)
Depends-on: [lib-common#611](https://github.com/openstack-k8s-operators/lib-common/pull/611)