### PR TITLE
Modify startup scripts for ovn-controller-ovs

### DIFF
--- a/templates/ovncontroller/bin/functions
+++ b/templates/ovncontroller/bin/functions
@@ -29,6 +29,15 @@ FLOWS_RESTORE_SCRIPT=$ovs_dir/flows-script
 FLOWS_RESTORE_DIR=$ovs_dir/saved-flows
 SAFE_TO_STOP_OVSDB_SERVER_SEMAPHORE=$ovs_dir/is_safe_to_stop_ovsdb_server
 
+# Variables declaration used by start-up optimization
+ovs_vswitchd_pid_file=/var/run/openvswitch/ovs-vswitchd.pid
+ovsdb_server_pid_file=/var/run/openvswitch/ovsdb-server.pid
+update_semaphore_file=/var/lib/openvswitch/update
+stop_vswitchd_script_file=/usr/local/bin/container-scripts/stop-vswitchd.sh
+stop_ovsdb_server_script_file=/usr/local/bin/container-scripts/stop-ovsdb-server.sh
+skip_ovsdb_server_stop_file=/var/lib/openvswitch/skip_stop_ovsdbserver
+skip_vswitchd_stop_file=/var/lib/openvswitch/skip_stop_vswitchd
+
 function cleanup_ovsdb_server_semaphore() {
     rm -f $SAFE_TO_STOP_OVSDB_SERVER_SEMAPHORE 2>&1 > /dev/null
 }

--- a/templates/ovncontroller/bin/start-vswitchd.sh
+++ b/templates/ovncontroller/bin/start-vswitchd.sh
@@ -15,6 +15,18 @@
 # under the License.
 
 source $(dirname $0)/functions
+
+# If we're on an update wait until past vswitchd process is stopped correctly
+if [ -f $update_semaphore_file ]; then
+    # In the middle of an update, wait until vswitchd is already stopped
+    while true; do
+        if [ ! -f $ovs_vswitchd_pid_file ]; then
+            break
+        fi
+        sleep 0.1
+    done
+fi
+
 wait_for_ovsdb_server
 
 # The order - first wait for db server, then set -ex - is important. Otherwise,
@@ -48,6 +60,10 @@ cleanup_flows_backup
 
 # Now, inform vswitchd that we are done.
 ovs-vsctl remove open_vswitch . other_config flow-restore-wait
+
+# At this point, ovsdb-server and vswitchd are already running, update (if it was the case)
+# is already done. Delete update file
+rm $update_semaphore_file || true
 
 # This is container command script. Block it from exiting, otherwise k8s will
 # restart the container again.

--- a/templates/ovncontroller/bin/stop-ovsdb-server.sh
+++ b/templates/ovncontroller/bin/stop-ovsdb-server.sh
@@ -17,6 +17,12 @@
 set -ex
 source $(dirname $0)/functions
 
+# If file is present, skip stop script
+if [ -f $skip_ovsdb_server_stop_file ]; then
+    rm $skip_ovsdb_server_stop_file
+    exit 0
+fi
+
 # The ovs_vswitchd container has to terminate before ovsdb-server because it
 # needs access to db in its preStop script. The preStop script backs up flows
 # for restoration during the next startup. This semaphore ensures the vswitchd

--- a/templates/ovncontroller/bin/stop-vswitchd.sh
+++ b/templates/ovncontroller/bin/stop-vswitchd.sh
@@ -17,6 +17,12 @@
 set -ex
 source $(dirname $0)/functions
 
+# If file is present, skip stop script
+if [ -f $skip_vswitchd_stop_file ]; then
+    rm $skip_vswitchd_stop_file
+    exit 0
+fi
+
 # Clean up any previously created flow backups to avoid conflict with newly
 # generated backup.
 cleanup_flows_backup


### PR DESCRIPTION
Modify startup scripts for ovn-controller-ovs
    
In order to minimize the downtime during update of the
ovn-controller-ovs pods we're modifying the update strategy so
it doesn't accept any Unavailable pod. This means that it will
create new ovn-controller-ovs while the old one is running.
    
This commit enables that two ovn-controller-ovs pods can coexists.
It accomplish this by modifying the start-up scripts of all containers
so it checks if a pod is already running and slowly stops in a
controlled fashon the old pods while it starts the new ones.
   
The logic is done with a temporary file created during the init
container that will inform the ovsdb-server/ovs-vswitchd containers
if they're on an update scenario or a normal one. The temporary file
is deleted after the end of the ovs-vswitchd so when the ovnController
CR is deleted, the volumes won't have any leftovers.
    
    Related: OSPRH-11636
    Jira: OSPRH-10821
    Depends-on: lib-common#611



This is an alternative to https://github.com/openstack-k8s-operators/ovn-operator/pull/423

TODO:

- [ ] Kuttl test
- [x] Logic to change gateway chassis priority