### PR TITLE
[ovn-controller-ovs] Compact OVSDB in init container

### DIFF
--- a/templates/ovncontroller/bin/init-ovsdb-server.sh
+++ b/templates/ovncontroller/bin/init-ovsdb-server.sh
@@ -23,6 +23,12 @@ trap wait_for_db_creation EXIT
 if ! [ -s ${DB_FILE} ]; then
     rm -f ${DB_FILE}
 fi
+
+# Compact the Database file if it exists
+if [ -f ${DB_FILE} ]; then
+    ovsdb-tool compact ${DB_FILE}
+fi
+
 # Initialize or upgrade database if needed
 CTL_ARGS="--system-id=random --no-ovs-vswitchd"
 /usr/share/openvswitch/scripts/ovs-ctl start $CTL_ARGS


### PR DESCRIPTION
If OVSDB get's large enough it impacts start up time. It is observed in a case for a DB ~ 2.5 GB it took 60+ seconds to start ovsdb which is higher than
configured liveness probes and due to this pod got stuck into a restart loop.
With this patch compacting OVSDB in init container if the db exists to avoid this issue.

Resolves: [OSPRH-17558](https://issues.redhat.com//browse/OSPRH-17558)