### PR TITLE
Accept IPv4 and IPv6 connections on ovsdbserver

### DIFF
--- a/templates/ovndbcluster/bin/setup.sh
+++ b/templates/ovndbcluster/bin/setup.sh
@@ -30,14 +30,8 @@ if [[ "${DB_TYPE}" == "sb" ]]; then
     DB_NAME="OVN_Southbound"
 fi
 
-PODNAME=$(hostname -f | cut -d. -f1,2)
-PODIPV6=$(grep "${PODNAME}" /etc/hosts | grep ':' | cut -d$'\t' -f1)
-
-if [[ "" = "${PODIPV6}" ]]; then
-    DB_ADDR="0.0.0.0"
-else
-    DB_ADDR="[::]"
-fi
+# [::] Works for both IPv4 and IPv6
+DB_ADDR="[::]"
 
 # The --cluster-remote-addr / --cluster-local-addr options will have effect
 # only on bootstrap, when we assume the leadership role for the first pod.


### PR DESCRIPTION
Until now we checked if the environment is using IPv4 or IPv6 in /etc/hosts, which depends on how the OCP control plane is specified. This is not accurate, since we can have IPv4 on the OCP control plane but IPv6 on the OCP dataplane. Therefore we implemented [::] as listening entry for both IPv4 and IPv6 environments. Even though we are not currently expecting dual-stack configurations [0] this works because OVN does have dual-stack capabilities.

[0] https://github.com/openstack-k8s-operators/install_yamls/blob/main/scripts/gen-netatt.sh#L40

Resolves: [OSPRH-5808](https://issues.redhat.com//browse/OSPRH-5808)