### PR TITLE
Disable caching for Deployment resource

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,10 +28,12 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"go.uber.org/zap/zapcore"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -108,6 +110,13 @@ func main() {
 				Port:    webhookPort,
 				TLSOpts: []func(config *tls.Config){disableHTTP2},
 			}),
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&appsv1.Deployment{},
+				},
+			},
+		},
 	}
 
 	err := operator.SetManagerOptions(&options, setupLog)


### PR DESCRIPTION
With [1] we switched to statefulset and did cleanup of deployment resource and removed 'watch' permission for deployment. But as controller-runtime implicit add the watch permissions for any Get/List request and with missing permissions below is seen in operator logs:-
tools/cache/reflector.go:229: Failed to watch *v1.Deployment: unknown (get deployments.apps)

Since we no longer rely on deployment resources, disabled caching for it.

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/475
Related-Issue: https://issues.redhat.com/browse/OSPRH-12568