### PR TITLE
Make metrics service label consistent

### DIFF
--- a/controllers/ovncontroller_controller.go
+++ b/controllers/ovncontroller_controller.go
@@ -700,7 +700,7 @@ func (r *OVNControllerReconciler) reconcileNormal(ctx context.Context, instance 
 
 		metricsLabels := map[string]string{
 			common.AppSelector: ovnv1.ServiceNameOVNControllerMetrics,
-			"type":             "metrics",
+			"metrics":          "enabled",
 		}
 
 		// Define a new DaemonSet object for OVNController metrics

--- a/controllers/ovnnorthd_controller.go
+++ b/controllers/ovnnorthd_controller.go
@@ -648,7 +648,7 @@ func (r *OVNNorthdReconciler) reconcileMetricsServices(
 
 		// Create StatefulSet pod-specific labels
 		metricsServiceLabels := util.MergeMaps(serviceLabels, map[string]string{
-			"type": "metrics",
+			"metrics": "enabled",
 		})
 
 		// StatefulSet pods have predictable names and stable labels

--- a/tests/kuttl/tests/ovn_metrics/03-errors.yaml
+++ b/tests/kuttl/tests/ovn_metrics/03-errors.yaml
@@ -8,11 +8,11 @@ kind: Service
 metadata:
   labels:
     service: ovn-northd
-    type: metrics
+    metrics: enabled
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     service: ovn-controller-metrics
-    type: metrics
+    metrics: enabled


### PR DESCRIPTION
"type" label is already used in ovndbcluster services for defining service type. For consistency adjusting it for northd and ovncontroller as being added for ovndbcluster[1].

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/480

Related-Issue: [OSPRH-12560](https://issues.redhat.com//browse/OSPRH-12560)
Related-Issue: [OSPRH-12568](https://issues.redhat.com//browse/OSPRH-12568)