### PR TITLE
Make metrics port a constant

### DIFF
--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -8,4 +8,7 @@ const (
 	// Metrics certificate paths
 	OVNMetricsCertPath string = "/etc/pki/tls/certs/ovnmetrics.crt"
 	OVNMetricsKeyPath  string = "/etc/pki/tls/private/ovnmetrics.key"
+
+	// Metrics port
+	MetricsPort int32 = 1981
 )

--- a/pkg/ovncontroller/service.go
+++ b/pkg/ovncontroller/service.go
@@ -2,6 +2,7 @@ package ovncontroller
 
 import (
 	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/ovn-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -24,7 +25,7 @@ func MetricsService(
 			Ports: []corev1.ServicePort{
 				{
 					Name:     "metrics",
-					Port:     1981,
+					Port:     common.MetricsPort,
 					Protocol: corev1.ProtocolTCP,
 				},
 			},

--- a/pkg/ovndbcluster/service.go
+++ b/pkg/ovndbcluster/service.go
@@ -2,6 +2,7 @@ package ovndbcluster
 
 import (
 	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/ovn-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -41,7 +42,7 @@ func Service(
 	if instance.Spec.ExporterImage != "" && (instance.Spec.MetricsEnabled == nil || *instance.Spec.MetricsEnabled) {
 		ports = append(ports, corev1.ServicePort{
 			Name:     "metrics",
-			Port:     1981,
+			Port:     common.MetricsPort,
 			Protocol: corev1.ProtocolTCP,
 		})
 	}

--- a/pkg/ovnnorthd/service.go
+++ b/pkg/ovnnorthd/service.go
@@ -2,6 +2,7 @@ package ovnnorthd
 
 import (
 	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/ovn-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -24,7 +25,7 @@ func MetricsService(
 			Ports: []corev1.ServicePort{
 				{
 					Name:     "metrics",
-					Port:     1981,
+					Port:     common.MetricsPort,
 					Protocol: corev1.ProtocolTCP,
 				},
 			},

--- a/tests/functional/ovncontroller_controller_test.go
+++ b/tests/functional/ovncontroller_controller_test.go
@@ -1488,7 +1488,7 @@ var _ = Describe("OVNController controller", func() {
 
 			svc := th.GetService(metricsServiceName)
 			Expect(svc.Spec.Ports).To(HaveLen(1))
-			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(1981)))
+			Expect(svc.Spec.Ports[0].Port).To(Equal(ovn_common.MetricsPort))
 			Expect(svc.Spec.Ports[0].Name).To(Equal("metrics"))
 		})
 	})

--- a/tests/functional/ovndbcluster_controller_test.go
+++ b/tests/functional/ovndbcluster_controller_test.go
@@ -31,6 +31,7 @@ import (
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
+	ovn_common "github.com/openstack-k8s-operators/ovn-operator/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -304,7 +305,7 @@ var _ = Describe("OVNDBCluster controller", func() {
 					// Should have metrics port
 					var hasMetricsPort bool
 					for _, port := range svc.Spec.Ports {
-						if port.Name == "metrics" && port.Port == 1981 {
+						if port.Name == "metrics" && port.Port == ovn_common.MetricsPort {
 							hasMetricsPort = true
 							break
 						}


### PR DESCRIPTION
Follow up of [1]

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/480
Related-Issue: https://issues.redhat.com/browse/OSPRH-12567
Assisted-by: Claude