### PR TITLE
[ovn-controller] Expose ovn-encap-tos external ids config

### DIFF
--- a/api/bases/ovn.openstack.org_ovncontrollers.yaml
+++ b/api/bases/ovn.openstack.org_ovncontrollers.yaml
@@ -75,6 +75,12 @@ spec:
                   ovn-bridge:
                     default: br-int
                     type: string
+                  ovn-encap-tos:
+                    default: "0"
+                    enum:
+                    - "0"
+                    - inherit
+                    type: string
                   ovn-encap-type:
                     default: geneve
                     enum:

--- a/api/v1beta1/ovncontroller_types.go
+++ b/api/v1beta1/ovncontroller_types.go
@@ -186,6 +186,11 @@ type OVSExternalIDs struct {
 	OvnEncapType string `json:"ovn-encap-type,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="0"
+	// +kubebuilder:validation:Enum={"0","inherit"}
+	OvnEncapTos string `json:"ovn-encap-tos,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={}
 	OvnAvailabilityZones []string `json:"availability-zones,omitempty"`
 

--- a/config/crd/bases/ovn.openstack.org_ovncontrollers.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovncontrollers.yaml
@@ -75,6 +75,12 @@ spec:
                   ovn-bridge:
                     default: br-int
                     type: string
+                  ovn-encap-tos:
+                    default: "0"
+                    enum:
+                    - "0"
+                    - inherit
+                    type: string
                   ovn-encap-type:
                     default: geneve
                     enum:

--- a/controllers/ovndbcluster_controller.go
+++ b/controllers/ovndbcluster_controller.go
@@ -1004,6 +1004,7 @@ func (r *OVNDBClusterReconciler) generateExternalConfigMaps(
 	}
 	if ovnController != nil {
 		externalTemplateParameters["OVNEncapType"] = ovnController.Spec.ExternalIDS.OvnEncapType
+		externalTemplateParameters["OVNEncapTos"] = ovnController.Spec.ExternalIDS.OvnEncapTos
 	}
 
 	cms := []util.Template{

--- a/pkg/ovncontroller/daemonset.go
+++ b/pkg/ovncontroller/daemonset.go
@@ -35,8 +35,8 @@ func CreateOVNDaemonSet(
 	labels map[string]string,
 	topology *topologyv1.Topology,
 ) *appsv1.DaemonSet {
-	volumes := GetOVNControllerVolumes(instance.Name, instance.Namespace)
-	mounts := GetOVNControllerVolumeMounts()
+	volumes := GetOVNControllerVolumes(instance.Name, instance.Namespace, false)
+	mounts := GetOVNControllerVolumeMounts(false)
 
 	cmd := []string{
 		"ovn-controller", "--pidfile", "unix:/run/openvswitch/db.sock",

--- a/templates/ovncontroller/config/configure-ovn.sh
+++ b/templates/ovncontroller/config/configure-ovn.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# This script configures ovn-encap-tos setting in OVS external-ids
+# It is only used when ovn-encap-tos is explicitly set to a non-default value
+
+source $(dirname $0)/../container-scripts/functions
+
+OVNEncapTos={{.OVNEncapTos}}
+
+function configure_ovn_external_ids {
+    ovs-vsctl set open . external-ids:ovn-encap-tos=${OVNEncapTos}
+}
+
+wait_for_ovsdb_server
+configure_ovn_external_ids

--- a/templates/ovndbcluster/config/ovsdb-config
+++ b/templates/ovndbcluster/config/ovsdb-config
@@ -1,4 +1,7 @@
 ovn-remote: {{ .OVNRemote }}
-{{if (index . "OVNEncapType")}}
+{{- if (index . "OVNEncapType") }}
 ovn-encap-type: {{ .OVNEncapType }}
-{{end}}
+{{- end }}
+{{- if (index . "OVNEncapTos") }}
+ovn-encap-tos: {{ .OVNEncapTos }}
+{{- end }}

--- a/tests/functional/ovndbcluster_controller_test.go
+++ b/tests/functional/ovndbcluster_controller_test.go
@@ -603,11 +603,13 @@ var _ = Describe("OVNDBCluster controller", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 
-		It("should create an external ConfigMap with ovn-encap-type if OVNController is configured", func() {
+		It("should create an external ConfigMap with ovn-encap-type and ovn-encap-tos if OVNController is configured", func() {
 			ExpectedEncapType := "vxlan"
+			ExpectedEncapTos := "inherit"
 			// Spawn OVNController with vxlan as ExternalIDs.OvnEncapType
 			ovncontrollerSpec := GetDefaultOVNControllerSpec()
 			ovncontrollerSpec.ExternalIDS.OvnEncapType = ExpectedEncapType
+			ovncontrollerSpec.ExternalIDS.OvnEncapTos = ExpectedEncapTos
 			ovnController := CreateOVNController(namespace, ovncontrollerSpec)
 			DeferCleanup(th.DeleteInstance, ovnController)
 			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
@@ -646,13 +648,19 @@ var _ = Describe("OVNDBCluster controller", func() {
 				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).Should(
 					ContainSubstring("ovn-encap-type: %s", ExpectedEncapType))
 			}, timeout, interval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).Should(
+					ContainSubstring("ovn-encap-tos: %s", ExpectedEncapTos))
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("should remove ovnEncapType if OVNController gets deleted", func() {
 			ExpectedEncapType := "vxlan"
+			ExpectedEncapTos := "inherit"
 			// Spawn OVNController with vxlan as ExternalIDs.OvnEncapType
 			ovncontrollerSpec := GetDefaultOVNControllerSpec()
 			ovncontrollerSpec.ExternalIDS.OvnEncapType = ExpectedEncapType
+			ovncontrollerSpec.ExternalIDS.OvnEncapTos = ExpectedEncapTos
 			ovnController := CreateOVNController(namespace, ovncontrollerSpec)
 			//DeferCleanup(th.DeleteInstance, ovnController)
 			internalAPINADName := types.NamespacedName{Namespace: namespace, Name: "internalapi"}
@@ -691,9 +699,13 @@ var _ = Describe("OVNDBCluster controller", func() {
 				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).Should(
 					ContainSubstring("ovn-encap-type: %s", ExpectedEncapType))
 			}, timeout, interval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).Should(
+					ContainSubstring("ovn-encap-tos: %s", ExpectedEncapTos))
+			}, timeout, interval).Should(Succeed())
 
 			// This should trigger an OVNDBCluster reconcile and update config map
-			// without ovn-encap-type
+			// without ovn-encap-type and ovn-encap-tos
 			DeleteOVNController(types.NamespacedName{Name: ovnController.GetName(), Namespace: namespace})
 
 			Eventually(func() corev1.ConfigMap {
@@ -706,6 +718,10 @@ var _ = Describe("OVNDBCluster controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).ShouldNot(
 					ContainSubstring("ovn-encap-type: %s", ExpectedEncapType))
+			}, timeout, interval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).ShouldNot(
+					ContainSubstring("ovn-encap-tos: %s", ExpectedEncapTos))
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -1036,11 +1052,13 @@ var _ = Describe("OVNDBCluster controller", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 
-		It("should create an external ConfigMap with ovn-encap-type if OVNController is configured", func() {
+		It("should create an external ConfigMap with ovn-encap-type and ovn-encap-tos if OVNController is configured", func() {
 			ExpectedEncapType := "vxlan"
+			ExpectedEncapTos := "inherit"
 			// Spawn OVNController with vxlan as ExternalIDs.OvnEncapType
 			ovncontrollerSpec := GetDefaultOVNControllerSpec()
 			ovncontrollerSpec.ExternalIDS.OvnEncapType = ExpectedEncapType
+			ovncontrollerSpec.ExternalIDS.OvnEncapTos = ExpectedEncapTos
 			ovnController := CreateOVNController(namespace, ovncontrollerSpec)
 			DeferCleanup(th.DeleteInstance, ovnController)
 
@@ -1077,13 +1095,19 @@ var _ = Describe("OVNDBCluster controller", func() {
 				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).Should(
 					ContainSubstring("ovn-encap-type: %s", ExpectedEncapType))
 			}, timeout, interval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).Should(
+					ContainSubstring("ovn-encap-tos: %s", ExpectedEncapTos))
+			}, timeout, interval).Should(Succeed())
 		})
 
-		It("should remove ovnEncapType if OVNController gets deleted", func() {
+		It("should remove ovnEncapType and ovnEncapTos if OVNController gets deleted", func() {
 			ExpectedEncapType := "vxlan"
+			ExpectedEncapTos := "inherit"
 			// Spawn OVNController with vxlan as ExternalIDs.OvnEncapType
 			ovncontrollerSpec := GetDefaultOVNControllerSpec()
 			ovncontrollerSpec.ExternalIDS.OvnEncapType = ExpectedEncapType
+			ovncontrollerSpec.ExternalIDS.OvnEncapTos = ExpectedEncapTos
 			ovnController := CreateOVNController(namespace, ovncontrollerSpec)
 
 			statefulSetName := types.NamespacedName{
@@ -1119,9 +1143,13 @@ var _ = Describe("OVNDBCluster controller", func() {
 				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).Should(
 					ContainSubstring("ovn-encap-type: %s", ExpectedEncapType))
 			}, timeout, interval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).Should(
+					ContainSubstring("ovn-encap-tos: %s", ExpectedEncapTos))
+			}, timeout, interval).Should(Succeed())
 
 			// This should trigger an OVNDBCluster reconcile and update config map
-			// without ovn-encap-type
+			// without ovn-encap-type and ovn-encap-tos
 			DeleteOVNController(types.NamespacedName{Name: ovnController.GetName(), Namespace: namespace})
 
 			Eventually(func() corev1.ConfigMap {
@@ -1134,6 +1162,10 @@ var _ = Describe("OVNDBCluster controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).ShouldNot(
 					ContainSubstring("ovn-encap-type: %s", ExpectedEncapType))
+			}, timeout, interval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(th.GetConfigMap(externalCM).Data["ovsdb-config"]).ShouldNot(
+					ContainSubstring("ovn-encap-tos: %s", ExpectedEncapTos))
 			}, timeout, interval).Should(Succeed())
 		})
 

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -68,6 +68,7 @@ spec:
   external-ids:
     ovn-bridge: br-int
     ovn-encap-type: geneve
+    ovn-encap-tos: "0"
     system-id: random
 status:
   conditions:


### PR DESCRIPTION
Similar was already supported for EDPM[1].
Also exposed in external Config Map to configure encap-tos similar to encap-type on the EDPM nodes.

Added addtional Config Map "ovncontroller-extra-scripts" and added it only to the config job to avoid restarts of ovn-controller and ovn-controller-ovs daemonsets.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/652

Related-Issue: https://issues.redhat.com/browse/OSPRH-6712
Resolves: https://issues.redhat.com/browse/OSPRH-19823

Assisted-By: claude