### PR TITLE
Change default namespace for kuttl tests

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -18,7 +18,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-ovn
-namespace: openstack
+namespace: ovn-kuttl-tests
 timeout: 600
 parallel: 1
 suppress:


### PR DESCRIPTION
Previously we were using the production namespace, "openstack". This is not convenient since it can overlap with pods that are from a development or production environment and it would be easier to have the same name as the one configured in install_yamls[0].

[0] https://github.com/openstack-k8s-operators/install_yamls/blob/main/Makefile#L236