### PR TITLE
[ovndbcluster] Handle db schema upgrade for larger DBs

### DIFF
--- a/templates/ovndbcluster/bin/functions
+++ b/templates/ovndbcluster/bin/functions
@@ -25,3 +25,46 @@ function wait_for_ovsdb_tool {
         sleep 1
     done
 }
+
+function wait_for_ovsdb_client {
+    while pgrep -a ovsdb-client; do
+        echo "ovsdb-client still working. Waiting..."
+        sleep 1
+    done
+}
+
+function check_and_convert_db {
+    local db_socket="/tmp/ovn${DB_TYPE}_db.sock"
+    local db_schema="/usr/share/ovn/ovn-${DB_TYPE}.ovsschema"
+
+    # Check prerequisites
+    if [ ! -f "$db_schema" ]; then
+        echo "Warning: Schema file $db_schema not found, skipping conversion check"
+        return
+    fi
+
+    if [ ! -S "$db_socket" ]; then
+        echo "Warning: Database socket $db_socket not found, skipping conversion check"
+        return
+    fi
+
+    # Check if conversion is needed
+    if test X"`ovsdb-client needs-conversion unix:$db_socket "$db_schema"`" = Xyes; then
+        echo "Database conversion needed for ${DB_TYPE} database, performing conversion..."
+
+        # Set trap to wait for ovsdb-client to finish conversion
+        trap wait_for_ovsdb_client EXIT
+
+        if ovsdb-client convert unix:$db_socket "$db_schema"; then
+            echo "Database conversion completed successfully for ${DB_TYPE} database"
+        else
+            echo "Error: Database conversion failed for ${DB_TYPE} database"
+            trap - EXIT
+            return 1
+        fi
+
+        # Wait for conversion to complete and remove trap
+        wait_for_ovsdb_client
+        trap - EXIT
+    fi
+}

--- a/templates/ovndbcluster/bin/setup.sh
+++ b/templates/ovndbcluster/bin/setup.sh
@@ -148,6 +148,10 @@ if [[ "$(hostname)" == "{{ .SERVICE_NAME }}-0" ]]; then
     unset OVN_${DB_TYPE^^}_DAEMON
 fi
 
+# Check and perform database conversion if needed
+# This can be cleaned up once https://redhat.atlassian.net/browse/FDP-3108 is fixed
+check_and_convert_db
+
 wait_for_ovsdb_tool
 trap - EXIT
 


### PR DESCRIPTION
If a cluster with larger ovn dbs is updated to a version where OVN DB schema is changed, we can hit by [1] if the conversion takes more than 30 seconds.

Until [1] is fixed added a workaround to detect
if schema upgrade is needed and do the conversion.

[1] https://redhat.atlassian.net/browse/FDP-3108
Resolves: #[OSPRH-28316](https://redhat.atlassian.net/browse/OSPRH-28316)
Assisted-By: Claude