### PR TITLE
[ovndbcluster] Allow config changes without pod restarts

### DIFF
--- a/api/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/api/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -260,8 +260,10 @@ spec:
                 type: object
               probeIntervalToActive:
                 default: 60000
-                description: Active probe interval from standby to active ovsdb-server
-                  remote
+                description: |-
+                  DEPRECATED: ProbeIntervalToActive is only relevant for active/standby ovsdb configurations.
+                  This parameter is not used in RAFT clustered deployments and will be ignored.
+                  Active probe interval from standby to active ovsdb-server remote
                 format: int32
                 type: integer
               replicas:

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -100,6 +100,8 @@ type OVNDBClusterSpecCore struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=60000
+	// DEPRECATED: ProbeIntervalToActive is only relevant for active/standby ovsdb configurations.
+	// This parameter is not used in RAFT clustered deployments and will be ignored.
 	// Active probe interval from standby to active ovsdb-server remote
 	ProbeIntervalToActive int32 `json:"probeIntervalToActive"`
 

--- a/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -260,8 +260,10 @@ spec:
                 type: object
               probeIntervalToActive:
                 default: 60000
-                description: Active probe interval from standby to active ovsdb-server
-                  remote
+                description: |-
+                  DEPRECATED: ProbeIntervalToActive is only relevant for active/standby ovsdb configurations.
+                  This parameter is not used in RAFT clustered deployments and will be ignored.
+                  Active probe interval from standby to active ovsdb-server remote
                 format: int32
                 type: integer
               replicas:

--- a/internal/controller/ovndbcluster_controller.go
+++ b/internal/controller/ovndbcluster_controller.go
@@ -46,6 +46,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/job"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
@@ -562,6 +563,7 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 	// create Configmap required for dbcluster input
 	// - %-config configmap holding minimal dbcluster config required to get the service up
 	//
+	// Create ConfigMaps with ALL parameters included for setup script (pods will use these)
 	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars, serviceName)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -660,6 +662,21 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 	stateful := sfset.GetStatefulSet()
 	if stateful.Generation == stateful.Status.ObservedGeneration {
 		instance.Status.ReadyCount = stateful.Status.ReadyReplicas
+	}
+
+	// Only run runtime config when all pods are ready and no rolling update in progress
+	if instance.Status.ReadyCount == *instance.Spec.Replicas &&
+		stateful.Status.UpdatedReplicas == *instance.Spec.Replicas {
+		err = r.reconcileRuntimeConfig(ctx, helper, instance, serviceLabels, serviceName)
+		if err != nil {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.ServiceConfigReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.ServiceConfigReadyErrorMessage,
+				err.Error()))
+			return ctrl.Result{}, err
+		}
 	}
 
 	// verify if network attachment matches expectations
@@ -1112,6 +1129,138 @@ func (r *OVNDBClusterReconciler) deleteExternalConfigMaps(
 	return nil
 }
 
+// reconcileRuntimeConfig - handle runtime configuration without pod restart using consolidated event-driven Jobs
+func (r *OVNDBClusterReconciler) reconcileRuntimeConfig(
+	ctx context.Context,
+	h *helper.Helper,
+	instance *ovnv1.OVNDBCluster,
+	serviceLabels map[string]string,
+	serviceName string,
+) error {
+	Log := r.GetLogger(ctx)
+
+	// Calculate combined hash for all runtime parameters using deterministic ordering
+	runtimeEnvVars := map[string]env.Setter{
+		"ElectionTimer":   env.SetValue(fmt.Sprintf("%d", instance.Spec.ElectionTimer)),
+		"InactivityProbe": env.SetValue(fmt.Sprintf("%d", instance.Spec.InactivityProbe)),
+		"LogLevel":        env.SetValue(instance.Spec.LogLevel),
+	}
+	mergedRuntimeVars := env.MergeEnvs([]corev1.EnvVar{}, runtimeEnvVars)
+	runtimeConfigHash, err := util.ObjectHash(mergedRuntimeVars)
+	if err != nil {
+		return err
+	}
+
+	// Check if any runtime config changed
+	runtimeConfigHashKey := "OvnDBClusterRuntimeConfigHash"
+	currentHash := instance.Status.Hash[runtimeConfigHashKey]
+
+	if runtimeConfigHash == currentHash {
+		// No changes detected
+		return nil
+	}
+
+	Log.Info("Runtime configuration changed",
+		"oldHash", currentHash,
+		"newHash", runtimeConfigHash,
+		"ElectionTimer", instance.Spec.ElectionTimer,
+		"InactivityProbe", instance.Spec.InactivityProbe,
+		"LogLevel", instance.Spec.LogLevel)
+
+	// Include all runtime configs for job creation when any changes detected
+	changedConfigs := map[string]interface{}{
+		"ElectionTimer":   instance.Spec.ElectionTimer,
+		"InactivityProbe": instance.Spec.InactivityProbe,
+		"LogLevel":        instance.Spec.LogLevel,
+	}
+
+	// Update hash BEFORE creating jobs to prevent continuous re-creation
+	instance.Status.Hash[runtimeConfigHashKey] = runtimeConfigHash
+
+	// Create runtime-config ConfigMap for the Jobs
+	err = r.ensureRuntimeConfigMap(ctx, h, instance, serviceName)
+	if err != nil {
+		Log.Error(err, "Failed to create runtime-config ConfigMap")
+		return err
+	}
+
+	// Create consolidated configuration jobs
+	jobsDef, err := ovndbcluster.RuntimeConfigJobs(ctx, r.Client, instance, serviceLabels, serviceName, changedConfigs)
+	if err != nil {
+		Log.Error(err, "Failed to create configuration Jobs")
+		return err
+	}
+
+	// Process each job using the job.NewJob pattern - submit ALL jobs first
+	var anyJobInProgress bool
+	for _, jobDef := range jobsDef {
+		configHashKey := "OvnDBClusterConfigHash-" + jobDef.Spec.Template.Spec.NodeName
+		configJob := job.NewJob(
+			jobDef,
+			configHashKey,
+			false,
+			time.Duration(5)*time.Second,
+			runtimeConfigHash,
+		)
+		ctrlResult, err := configJob.DoJob(ctx, h)
+		if err != nil {
+			Log.Error(err, "Failed to execute configuration job")
+			return err
+		}
+		if (ctrlResult != ctrl.Result{}) {
+			Log.Info("Configuration job in progress", "nodeName", jobDef.Spec.Template.Spec.NodeName)
+			anyJobInProgress = true // Don't return early, continue processing remaining jobs
+		}
+	}
+
+	// Return early only after ALL jobs have been submitted
+	if anyJobInProgress {
+		Log.Info("Some configuration jobs still in progress - requeuing")
+		return nil
+	}
+
+	Log.Info("All configuration jobs completed successfully")
+
+	return nil
+}
+
+// ensureRuntimeConfigMap creates the runtime-config ConfigMap needed by configuration Jobs
+func (r *OVNDBClusterReconciler) ensureRuntimeConfigMap(
+	ctx context.Context,
+	h *helper.Helper,
+	instance *ovnv1.OVNDBCluster,
+	serviceName string,
+) error {
+	// Create template parameters for runtime config script
+	templateParameters := make(map[string]any)
+	templateParameters["SERVICE_NAME"] = serviceName
+	templateParameters["DB_TYPE"] = strings.ToLower(instance.Spec.DBType)
+	templateParameters["DB_PORT"] = ovndbcluster.DbPortNB
+	if instance.Spec.DBType == ovnv1.SBDBType {
+		templateParameters["DB_PORT"] = ovndbcluster.DbPortSB
+	}
+	templateParameters["TLS"] = instance.Spec.TLS.Enabled()
+
+	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(serviceName), map[string]string{})
+
+	cms := []util.Template{
+		{
+			Name:      fmt.Sprintf("%s-runtime-config", instance.Name),
+			Namespace: instance.Namespace,
+			Type:      util.TemplateTypeNone,
+			AdditionalTemplate: map[string]string{
+				"runtime-config.sh": "/ovndbcluster/config/runtime-config.sh",
+			},
+			InstanceType:  instance.Kind,
+			Labels:        cmLabels,
+			ConfigOptions: templateParameters,
+		},
+	}
+
+	// Create just the runtime-config ConfigMap
+	return configmap.EnsureConfigMaps(ctx, h, instance, cms, &map[string]env.Setter{})
+}
+
 // generateServiceConfigMaps - create create configmaps which hold service configuration
 func (r *OVNDBClusterReconciler) generateServiceConfigMaps(
 	ctx context.Context,
@@ -1125,7 +1274,6 @@ func (r *OVNDBClusterReconciler) generateServiceConfigMaps(
 
 	templateParameters := make(map[string]any)
 
-	templateParameters["OVN_LOG_LEVEL"] = instance.Spec.LogLevel
 	templateParameters["SERVICE_NAME"] = serviceName
 	templateParameters["NAMESPACE"] = instance.GetNamespace()
 	templateParameters["DB_TYPE"] = strings.ToLower(instance.Spec.DBType)
@@ -1135,15 +1283,13 @@ func (r *OVNDBClusterReconciler) generateServiceConfigMaps(
 		templateParameters["DB_PORT"] = ovndbcluster.DbPortSB
 		templateParameters["RAFT_PORT"] = ovndbcluster.RaftPortSB
 	}
-	templateParameters["OVN_ELECTION_TIMER"] = instance.Spec.ElectionTimer
-	templateParameters["OVN_INACTIVITY_PROBE"] = instance.Spec.InactivityProbe
-	templateParameters["OVN_PROBE_INTERVAL_TO_ACTIVE"] = instance.Spec.ProbeIntervalToActive
 	templateParameters["TLS"] = instance.Spec.TLS.Enabled()
 	templateParameters["OVNDB_CERT_PATH"] = ovn_common.OVNDbCertPath
 	templateParameters["OVNDB_KEY_PATH"] = ovn_common.OVNDbKeyPath
 	templateParameters["OVNDB_CACERT_PATH"] = ovn_common.OVNDbCaCertPath
 	templateParameters["OVN_METRICS_CERT_PATH"] = ovn_common.OVNMetricsCertPath
 	templateParameters["OVN_METRICS_KEY_PATH"] = ovn_common.OVNMetricsKeyPath
+	templateParameters["OVN_RUNDIR"] = "/etc/ovn"
 
 	cms := []util.Template{
 		// ScriptsConfigMap

--- a/internal/ovndbcluster/runtimeconfigjob.go
+++ b/internal/ovndbcluster/runtimeconfigjob.go
@@ -1,0 +1,191 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ovndbcluster provides functionality for managing OVN database cluster components
+package ovndbcluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
+	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RuntimeConfigJobs - create single job per pod that handles all runtime configuration changes
+func RuntimeConfigJobs(
+	ctx context.Context,
+	k8sClient client.Client,
+	instance *ovnv1.OVNDBCluster,
+	labels map[string]string,
+	serviceName string,
+	changedConfigs map[string]interface{}, // Map of changed configuration parameters
+) ([]*batchv1.Job, error) {
+
+	var jobs []*batchv1.Job
+	// NOTE: set TTLSecondsAfterFinished=0 will clean done
+	// configuration job automatically right after it will be finished
+	jobTTLAfterFinished := int32(0)
+
+	// Get all pods in the StatefulSet
+	ovnPods, err := getOVNDBClusterPods(
+		ctx,
+		k8sClient,
+		instance,
+		serviceName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a single consolidated job per pod
+	jobs = createConsolidatedConfigJobs(instance, ovnPods.Items, labels, jobTTLAfterFinished, changedConfigs)
+
+	return jobs, nil
+}
+
+// createConsolidatedConfigJobs - create single job per pod that handles all runtime config changes
+func createConsolidatedConfigJobs(instance *ovnv1.OVNDBCluster, pods []corev1.Pod, labels map[string]string, jobTTL int32, changedConfigs map[string]interface{}) []*batchv1.Job {
+	var jobs []*batchv1.Job
+
+	for _, pod := range pods {
+		// More inclusive pod status check - skip only clearly unavailable pods
+		if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded || pod.DeletionTimestamp != nil {
+			continue
+		}
+
+		// Create list of configuration changes to process
+		var configFlags []string
+		if _, exists := changedConfigs["ElectionTimer"]; exists {
+			configFlags = append(configFlags, "ELECTION_TIMER")
+		}
+		if _, exists := changedConfigs["LogLevel"]; exists {
+			configFlags = append(configFlags, "LOG_LEVEL")
+		}
+		if _, exists := changedConfigs["InactivityProbe"]; exists {
+			configFlags = append(configFlags, "INACTIVITY_PROBE")
+		}
+
+		// Skip if no changes detected
+		if len(configFlags) == 0 {
+			continue
+		}
+
+		// Create environment variables for the script (minimal set)
+		envVars := map[string]env.Setter{
+			"ELECTION_TIMER":   env.SetValue(fmt.Sprintf("%d", instance.Spec.ElectionTimer)),
+			"LOG_LEVEL":        env.SetValue(instance.Spec.LogLevel),
+			"INACTIVITY_PROBE": env.SetValue(fmt.Sprintf("%d", instance.Spec.InactivityProbe)),
+			"CONFIG_FLAGS":     env.SetValue(strings.Join(configFlags, " ")),
+		}
+
+		// Use the runtime-config script from ConfigMap volume
+		commands := []string{
+			"/bin/bash",
+			"/etc/config/runtime-config.sh",
+		}
+
+		// Use timestamp to ensure unique job names and avoid conflicts
+		jobName := fmt.Sprintf("%s-config-%d", pod.Name, metav1.Now().Unix())
+
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      jobName,
+				Namespace: instance.Namespace,
+				Labels:    labels,
+			},
+			Spec: batchv1.JobSpec{
+				TTLSecondsAfterFinished: &jobTTL,
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						RestartPolicy:      corev1.RestartPolicyOnFailure,
+						ServiceAccountName: instance.RbacResourceName(),
+						Containers: []corev1.Container{
+							{
+								Name:    "ovn-config",
+								Image:   instance.Spec.ContainerImage,
+								Command: commands,
+								Env:     env.MergeEnvs([]corev1.EnvVar{}, envVars),
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "ovn-db-data",
+										MountPath: "/etc/ovn",
+									},
+									{
+										Name:      "config-scripts",
+										MountPath: "/etc/config",
+										ReadOnly:  true,
+									},
+								},
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "ovn-db-data",
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: fmt.Sprintf("%s%s-%s", instance.Name, PVCSuffixEtcOVN, pod.Name),
+									},
+								},
+							},
+							{
+								Name: "config-scripts",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: fmt.Sprintf("%s-runtime-config", instance.Name),
+										},
+										DefaultMode: func() *int32 { mode := int32(0755); return &mode }(),
+									},
+								},
+							},
+						},
+						NodeName: pod.Spec.NodeName,
+					},
+				},
+			},
+		}
+		jobs = append(jobs, job)
+	}
+
+	return jobs
+}
+
+// getOVNDBClusterPods returns the pods belonging to the OVNDBCluster StatefulSet
+func getOVNDBClusterPods(
+	ctx context.Context,
+	k8sClient client.Client,
+	instance *ovnv1.OVNDBCluster,
+	serviceName string,
+) (*corev1.PodList, error) {
+	ovnPods := &corev1.PodList{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace(instance.Namespace),
+		client.MatchingLabels{
+			"service": serviceName,
+		},
+	}
+
+	err := k8sClient.List(ctx, ovnPods, listOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return ovnPods, nil
+}

--- a/internal/ovndbcluster/statefulset.go
+++ b/internal/ovndbcluster/statefulset.go
@@ -106,7 +106,7 @@ func StatefulSet(
 	envVars := map[string]env.Setter{}
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 	// TODO: Make confs customizable
-	envVars["OVN_RUNDIR"] = env.SetValue("/tmp")
+	envVars["OVN_RUNDIR"] = env.SetValue("/etc/ovn")
 	// we have to set LOGDIR even though we don't want to log to file. This is
 	// because ovsdb-server will still attempt to write a line into the file
 	// before seizing file logging, and the default log file location is not
@@ -170,12 +170,13 @@ func StatefulSet(
 	if instance.Spec.ExporterImage != "" && (instance.Spec.MetricsEnabled == nil || *instance.Spec.MetricsEnabled) {
 		metricsVolumeMounts := []corev1.VolumeMount{
 			{
-				Name:      "ovsdb-rundir",
-				MountPath: "/tmp",
-			},
-			{
 				Name:      "config",
 				MountPath: "/etc/config",
+				ReadOnly:  true,
+			},
+			{
+				Name:      instance.Name + PVCSuffixEtcOVN,
+				MountPath: "/etc/ovn",
 				ReadOnly:  true,
 			},
 		}

--- a/internal/ovndbcluster/volumes.go
+++ b/internal/ovndbcluster/volumes.go
@@ -21,12 +21,6 @@ func GetDBClusterVolumes(name string) []corev1.Volume {
 			},
 		},
 		{
-			Name: "ovsdb-rundir",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		},
-		{
 			Name: "config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -53,10 +47,6 @@ func GetDBClusterVolumeMounts(name string) []corev1.VolumeMount {
 			Name:      name,
 			MountPath: "/etc/ovn",
 			ReadOnly:  false,
-		},
-		{
-			Name:      "ovsdb-rundir",
-			MountPath: "/tmp",
 		},
 	}
 

--- a/templates/ovndbcluster/bin/cleanup.sh
+++ b/templates/ovndbcluster/bin/cleanup.sh
@@ -24,12 +24,12 @@ fi
 # There is nothing special about -0 pod, except that it's always guaranteed to
 # exist, assuming any replicas are ordered.
 if [[ "$(hostname)" != "{{ .SERVICE_NAME }}-0" ]]; then
-    ovs-appctl -t /tmp/ovn${DB_TYPE}_db.ctl cluster/leave ${DB_NAME}
+    ovs-appctl -t ${OVN_RUNDIR}/ovn${DB_TYPE}_db.ctl cluster/leave ${DB_NAME}
 
     # wait for when the leader confirms we left the cluster
     while true; do
         # TODO: is there a better way to detect the cluster left state?..
-        STATUS=$(ovs-appctl -t /tmp/ovn${DB_TYPE}_db.ctl cluster/status ${DB_NAME} | grep Status: | awk -e '{print $2}')
+        STATUS=$(ovs-appctl -t ${OVN_RUNDIR}/ovn${DB_TYPE}_db.ctl cluster/status ${DB_NAME} | grep Status: | awk -e '{print $2}')
         if [ -z "$STATUS" -o "x$STATUS" = "xleft cluster" ]; then
             break
         fi

--- a/templates/ovndbcluster/bin/functions
+++ b/templates/ovndbcluster/bin/functions
@@ -34,7 +34,7 @@ function wait_for_ovsdb_client {
 }
 
 function check_and_convert_db {
-    local db_socket="/tmp/ovn${DB_TYPE}_db.sock"
+    local db_socket="${OVN_RUNDIR}/ovn${DB_TYPE}_db.sock"
     local db_schema="/usr/share/ovn/ovn-${DB_TYPE}.ovsschema"
 
     # Check prerequisites
@@ -67,4 +67,14 @@ function check_and_convert_db {
         wait_for_ovsdb_client
         trap - EXIT
     fi
+}
+
+function cleanup_stale_runtime_files {
+    # Remove specific runtime files that may persist in PVC across pod restarts
+    # These can prevent service startup if left from previous crashed containers
+    rm -f "${OVN_RUNDIR}/ovn${DB_TYPE}_db.ctl"         # Control socket
+    rm -f "${OVN_RUNDIR}/ovn${DB_TYPE}_db.sock"        # Unix socket
+    rm -f "${OVN_RUNDIR}/ovn${DB_TYPE}_db.pid"         # Main PID file
+    rm -f "${OVN_RUNDIR}/ovn-${DB_TYPE}ctl.pid"        # Control daemon PID file
+    rm -f "${OVN_RUNDIR}/.ovn${DB_TYPE}_db.db.~lock~"  # Database lock file
 }

--- a/templates/ovndbcluster/bin/ovndb_readiness.sh
+++ b/templates/ovndbcluster/bin/ovndb_readiness.sh
@@ -23,7 +23,7 @@ error_exit() {
 }
 
 # Set socket path based on database type from functions
-SOCKET_PATH="/tmp/ovn${DB_TYPE}_db.ctl"
+SOCKET_PATH="${OVN_RUNDIR}/ovn${DB_TYPE}_db.ctl"
 
 # Set database name based on type
 DB_NAME="OVN_Northbound"

--- a/templates/ovndbcluster/bin/setup.sh
+++ b/templates/ovndbcluster/bin/setup.sh
@@ -47,10 +47,10 @@ fi
 # extra_args after --
 set /usr/share/ovn/scripts/ovn-ctl --no-monitor
 
-set "$@" --db-${DB_TYPE}-election-timer={{ .OVN_ELECTION_TIMER }}
+# Election timer (hardcoded initial value; runtime changes handled by operator)
+set "$@" --db-${DB_TYPE}-election-timer=10000
 set "$@" --db-${DB_TYPE}-cluster-local-addr=$(hostname).{{ .SERVICE_NAME }}.${NAMESPACE}.svc.cluster.local
 set "$@" --db-${DB_TYPE}-cluster-local-port=${RAFT_PORT}
-set "$@" --db-${DB_TYPE}-probe-interval-to-active={{ .OVN_PROBE_INTERVAL_TO_ACTIVE }}
 set "$@" --db-${DB_TYPE}-addr=${DB_ADDR}
 set "$@" --db-${DB_TYPE}-port=${DB_PORT}
 {{- if .TLS }}
@@ -65,8 +65,8 @@ set "$@" --db-${DB_TYPE}-cluster-local-proto=tcp
 set "$@" --db-${DB_TYPE}-cluster-remote-proto=tcp
 {{- end }}
 
-# log to console
-set "$@" --ovn-${DB_TYPE}-log=-vconsole:{{ .OVN_LOG_LEVEL }}
+# log to console (hardcoded initial log level; runtime changes handled by operator)
+set "$@" --ovn-${DB_TYPE}-log=-vconsole:info
 
 # if server attempts to log to file, ignore
 #
@@ -74,6 +74,9 @@ set "$@" --ovn-${DB_TYPE}-log=-vconsole:{{ .OVN_LOG_LEVEL }}
 # create a log file -> this argument makes sure it doesn't polute OVN_LOGDIR
 # with a nearly empty log file
 set "$@" --ovn-${DB_TYPE}-logfile=/dev/null
+
+# Clean up stale runtime files that may persist in PVC across pod restarts
+cleanup_stale_runtime_files
 
 # If db file is empty, remove it; otherwise service won't start.
 # See https://issues.redhat.com/browse/FDP-689 for more details.
@@ -123,8 +126,11 @@ if [[ "$(hostname)" == "{{ .SERVICE_NAME }}-0" ]]; then
 {{- else }}
     ${CTLCMD} del-ssl
 {{- end }}
+    CURRENT_PROBE="$(${CTLCMD} get connection . inactivity_probe || echo [])"
+    if [ "$CURRENT_PROBE" = "[]" ]; then
+        CURRENT_PROBE=60000
+    fi
     ${CTLCMD} set-connection ${DB_SCHEME}:${DB_PORT}:${DB_ADDR}
-
     # OVN does not support setting inactivity-probe through --remote cli arg so
     # we have to set it after database is up.
     #
@@ -138,8 +144,8 @@ if [[ "$(hostname)" == "{{ .SERVICE_NAME }}-0" ]]; then
     # TODO: Consider migrating inactivity probe setting  to config files when
     # we update to ovs 3.3. See --config-file in ovsdb-server(1) for more
     # details.
-    while [ "$(${CTLCMD} get connection . inactivity_probe)" != "{{ .OVN_INACTIVITY_PROBE }}" ]; do
-        ${CTLCMD} --inactivity-probe={{ .OVN_INACTIVITY_PROBE }} set-connection ${DB_SCHEME}:${DB_PORT}:${DB_ADDR}
+    while [ "$(${CTLCMD} get connection . inactivity_probe)" != "${CURRENT_PROBE}" ]; do
+        ${CTLCMD} --inactivity-probe="${CURRENT_PROBE}" set-connection ${DB_SCHEME}:${DB_PORT}:${DB_ADDR}
     done
     ${CTLCMD} list connection
 

--- a/templates/ovndbcluster/config/openstack-network-exporter.yaml
+++ b/templates/ovndbcluster/config/openstack-network-exporter.yaml
@@ -1,4 +1,4 @@
-ovsdb-rundir: /tmp
+ovsdb-rundir: {{ .OVN_RUNDIR }}
 collectors: ['ovsdbserver']
 {{- if .TLS }}
 tls-cert: {{ .OVN_METRICS_CERT_PATH }}

--- a/templates/ovndbcluster/config/runtime-config.sh
+++ b/templates/ovndbcluster/config/runtime-config.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# OVN Database Runtime Configuration Script
+# Handles election timer, log level, and inactivity probe changes
+#
+set -e
+
+DB_TYPE="{{ .DB_TYPE }}"
+DB_PORT="{{ .DB_PORT }}"
+{{- if .TLS }}
+DB_SCHEME="pssl"
+{{- else }}
+DB_SCHEME="ptcp"
+{{- end }}
+SERVICE_NAME="{{ .SERVICE_NAME }}"
+
+# Set DB_NAME based on DB_TYPE (same logic as setup.sh)
+DB_NAME="OVN_Northbound"
+if [[ "${DB_TYPE}" == "sb" ]]; then
+    DB_NAME="OVN_Southbound"
+fi
+
+# Runtime configuration parameters
+ELECTION_TIMER="${ELECTION_TIMER:-10000}"
+LOG_LEVEL="${LOG_LEVEL:-info}"
+INACTIVITY_PROBE="${INACTIVITY_PROBE:-60000}"
+
+# Configuration flags (space-separated list of what to configure)
+CONFIG_FLAGS="${CONFIG_FLAGS:-}"
+
+# Set OVN_RUNDIR so ovn-ctl commands use correct paths
+export OVN_RUNDIR="/etc/ovn"
+
+SOCKET_PATH="/etc/ovn/ovn${DB_TYPE}_db.ctl"
+
+echo "=== OVN Runtime Configuration ==="
+echo "Pod: $(hostname)"
+echo "DB Type: ${DB_TYPE}"
+echo "Socket: ${SOCKET_PATH}"
+echo "Configurations to apply: ${CONFIG_FLAGS}"
+echo "=================================="
+
+# Check if control socket exists
+if [ ! -S "$SOCKET_PATH" ]; then
+    echo "ERROR: Control socket $SOCKET_PATH not available"
+    echo "Contents of /etc/ovn directory:"
+    ls -la /etc/ovn/ || true
+    exit 1
+fi
+
+# Configure Election Timer
+if echo "$CONFIG_FLAGS" | grep -q "ELECTION_TIMER"; then
+    echo "Configuring election timer to ${ELECTION_TIMER}ms..."
+    if ovs-appctl -t "$SOCKET_PATH" cluster/change-election-timer "$DB_NAME" "$ELECTION_TIMER"; then
+        echo "✓ Successfully configured election timer"
+    else
+        echo "⚠ Failed to configure election timer (expected if not leader)"
+    fi
+fi
+
+# Configure Log Level
+if echo "$CONFIG_FLAGS" | grep -q "LOG_LEVEL"; then
+    echo "Configuring log level to ${LOG_LEVEL}..."
+    if ovn-appctl -t "$SOCKET_PATH" vlog/set "console:${LOG_LEVEL}"; then
+        echo "✓ Successfully configured log level"
+    else
+        echo "✗ Failed to configure log level"
+        exit 1
+    fi
+fi
+
+# Configure Inactivity Probe (only on pod-0)
+if echo "$CONFIG_FLAGS" | grep -q "INACTIVITY_PROBE"; then
+    if [[ "$(hostname)" == "${SERVICE_NAME}-0-config-"* ]]; then
+        echo "Configuring inactivity probe to ${INACTIVITY_PROBE}ms on pod-0..."
+
+        # Simple approach - connect directly to running database (OVN_RUNDIR already set)
+        if ovn-${DB_TYPE}ctl --no-leader-only set connection . inactivity_probe="$INACTIVITY_PROBE"; then
+            echo "✓ Successfully configured inactivity probe"
+        else
+            echo "✗ Failed to configure inactivity probe"
+            exit 1
+        fi
+    else
+        echo "⚠ Skipping inactivity probe configuration (not pod-0)"
+    fi
+fi
+
+echo "=== Configuration completed successfully ==="

--- a/test/functional/ovndbcluster_controller_test.go
+++ b/test/functional/ovndbcluster_controller_test.go
@@ -272,15 +272,18 @@ var _ = Describe("OVNDBCluster controller", func() {
 
 			// Check metrics container volume mounts
 			th.AssertVolumeMountExists("config", "", metricsC.VolumeMounts)
-			th.AssertVolumeMountExists("ovsdb-rundir", "", metricsC.VolumeMounts)
+			th.AssertVolumeMountExists(OVNDBClusterName.Name+"-etc-ovn", "", metricsC.VolumeMounts)
 		})
 
 		It("creates the required volumes for metrics", func() {
 			sts := th.GetStatefulSet(statefulSetName)
 
-			// Verify required volumes exist
-			th.AssertVolumeExists("ovsdb-rundir", sts.Spec.Template.Spec.Volumes)
+			// Verify required ConfigMap volumes exist
 			th.AssertVolumeExists("config", sts.Spec.Template.Spec.Volumes)
+
+			// Verify VolumeClaimTemplate exists for PVC volume (VolumeClaimTemplates don't appear in volumes list)
+			Expect(sts.Spec.VolumeClaimTemplates).To(HaveLen(1))
+			Expect(sts.Spec.VolumeClaimTemplates[0].Name).To(Equal(OVNDBClusterName.Name + "-etc-ovn"))
 		})
 
 		It("creates the metrics config ConfigMap", func() {

--- a/test/kuttl/common/scripts/check_cluster_status.sh
+++ b/test/kuttl/common/scripts/check_cluster_status.sh
@@ -27,7 +27,7 @@ done
 for pod in "${pods[@]}"; do
 
     echo "Checking status of $pod"
-    output=$(oc exec $pod -n $NAMESPACE -- bash -c "OVS_RUNDIR=/tmp ovs-appctl -t /tmp/$CTL_FILE cluster/status $DB_NAME")
+    output=$(oc exec $pod -n $NAMESPACE -- bash -c "OVS_RUNDIR=/etc/ovn ovs-appctl -t /etc/ovn/$CTL_FILE cluster/status $DB_NAME")
 
     # Example of part of output string that needs parsing:
     # Status: cluster member

--- a/test/kuttl/tests/ovn_config/04-assert.yaml
+++ b/test/kuttl/tests/ovn_config/04-assert.yaml
@@ -1,0 +1,65 @@
+#
+# Check for:
+#
+# - Election timer, inactivity probe, and log level configured correctly in NB and SB databases
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+commands:
+    - script: |
+        # Wait for config Jobs to complete
+        # Give some time for jobs to be created after the patch
+        sleep 10
+        oc wait --for=condition=complete --timeout=120s job -n $NAMESPACE --field-selector metadata.name!='' --all 2>/dev/null || true
+
+        # Check NB election timer
+        nb_pod=$(oc get pod -n $NAMESPACE -l service=ovsdbserver-nb -o name|head -1)
+        election_timer_nb=$(oc rsh -n $NAMESPACE ${nb_pod} ovs-appctl -t /etc/ovn/ovnnb_db.ctl cluster/status OVN_Northbound | grep "Election timer" | awk '{print $3}' || echo "")
+        if [ "$election_timer_nb" != "15000" ]; then
+          echo "Expected NB election timer 15000, got: $election_timer_nb"
+          exit 1
+        fi
+
+        # Check SB election timer
+        sb_pod=$(oc get pod -n $NAMESPACE -l service=ovsdbserver-sb -o name|head -1)
+        election_timer_sb=$(oc rsh -n $NAMESPACE ${sb_pod} ovs-appctl -t /etc/ovn/ovnsb_db.ctl cluster/status OVN_Southbound | grep "Election timer" | awk '{print $3}' || echo "")
+        if [ "$election_timer_sb" != "20000" ]; then
+          echo "Expected SB election timer 20000, got: $election_timer_sb"
+          exit 1
+        fi
+
+        # Check NB inactivity probe (use pod-0 for connection settings)
+        nb_pod0=$(oc get pod -n $NAMESPACE -l service=ovsdbserver-nb -o name | grep '\-0' | head -1)
+        inactivity_probe_nb=$(oc rsh -n $NAMESPACE ${nb_pod0} ovn-nbctl --no-leader-only get connection . inactivity_probe || echo "")
+        if [ "$inactivity_probe_nb" != "45000" ]; then
+          echo "Expected NB inactivity probe 45000, got: $inactivity_probe_nb"
+          exit 1
+        fi
+
+        # Check SB inactivity probe (use pod-0 for connection settings)
+        sb_pod0=$(oc get pod -n $NAMESPACE -l service=ovsdbserver-sb -o name | grep '\-0' | head -1)
+        inactivity_probe_sb=$(oc rsh -n $NAMESPACE ${sb_pod0} ovn-sbctl --no-leader-only get connection . inactivity_probe || echo "")
+        if [ "$inactivity_probe_sb" != "50000" ]; then
+          echo "Expected SB inactivity probe 50000, got: $inactivity_probe_sb"
+          exit 1
+        fi
+
+        # Check NB log level - should be WARN (uppercase)
+        log_level_nb=$(oc rsh -n $NAMESPACE ${nb_pod} ovn-appctl -t /etc/ovn/ovnnb_db.ctl vlog/list | tail -1 | awk '{print $2}' || echo "")
+        if [ "$log_level_nb" != "WARN" ]; then
+          echo "Expected NB log level 'WARN', got: $log_level_nb"
+          oc rsh -n $NAMESPACE ${nb_pod} ovn-appctl -t /etc/ovn/ovnnb_db.ctl vlog/list | tail -1
+          exit 1
+        fi
+
+        # Check SB log level - should be WARN (uppercase)
+        log_level_sb=$(oc rsh -n $NAMESPACE ${sb_pod} ovn-appctl -t /etc/ovn/ovnsb_db.ctl vlog/list | tail -1 | awk '{print $2}' || echo "")
+        if [ "$log_level_sb" != "WARN" ]; then
+          echo "Expected SB log level 'WARN', got: $log_level_sb"
+          oc rsh -n $NAMESPACE ${sb_pod} ovn-appctl -t /etc/ovn/ovnsb_db.ctl vlog/list | tail -1
+          exit 1
+        fi
+
+        echo "All configuration values (election timer, inactivity probe, log level) verified successfully"
+        exit 0

--- a/test/kuttl/tests/ovn_config/04-config-patch.yaml
+++ b/test/kuttl/tests/ovn_config/04-config-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      # Patch NB cluster with all runtime configuration changes
+      oc patch OVNDBCluster -n $NAMESPACE ovndbcluster-nb-sample --type='json' -p='[
+        {"op": "replace", "path": "/spec/electionTimer", "value": 15000},
+        {"op": "replace", "path": "/spec/inactivityProbe", "value": 45000},
+        {"op": "replace", "path": "/spec/logLevel", "value": "warn"}
+      ]'
+
+      # Patch SB cluster with all runtime configuration changes
+      oc patch OVNDBCluster -n $NAMESPACE ovndbcluster-sb-sample --type='json' -p='[
+        {"op": "replace", "path": "/spec/electionTimer", "value": 20000},
+        {"op": "replace", "path": "/spec/inactivityProbe", "value": 50000},
+        {"op": "replace", "path": "/spec/logLevel", "value": "warn"}
+      ]'


### PR DESCRIPTION
Currently for any config change pod get's restart which we don't need for configs like:-
- ElectionTimer
- InactivityProbe
- LogLevel

Deprecated probeIntervalToActive config option as
that is not relevant only for active/standby db clusters which we are not using here.

Also using db directories(as persistent) for OVN_RUNDIR, so we can use them in job pods to do the config changes.

Resolves: #[OSPRH-27985](https://redhat.atlassian.net/browse/OSPRH-27985)
Assisted-By: Claude