### PR TITLE
Fix ovn_tls_enable kuttl test deployment phase

### DIFF
--- a/test/kuttl/tests/ovn_tls_enable/deploy/kustomization.yaml
+++ b/test/kuttl/tests/ovn_tls_enable/deploy/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ovn_v1beta1_ovndbcluster.yaml
+- ovn_v1beta1_ovnnorthd.yaml
+- ovn_v1beta1_ovncontroller.yaml
 patches:
 - patch: |-
     - op: add


### PR DESCRIPTION
There was missing creation of the ovn-northd and ovn-controller resources in the kustomization.yaml file in the 01-deploy-ovn phase in that test.

Related-bug: #[OSPRH-1922](https://redhat.atlassian.net/browse/OSPRH-1922)