### PR TITLE
Sanitize logLevel CR field

### DIFF
--- a/api/bases/ovn.openstack.org_ovncontrollers.yaml
+++ b/api/bases/ovn.openstack.org_ovncontrollers.yaml
@@ -152,8 +152,15 @@ spec:
                 type: string
               ovnLogLevel:
                 default: info
-                description: OVNLogLevel - Set log level off, emer, err, warn, info,
+                description: OVNLogLevel - Set log level off, emer, err, warn, info
                   or dbg. Default is info.
+                enum:
+                - "off"
+                - emer
+                - err
+                - warn
+                - info
+                - dbg
                 type: string
               ovsContainerImage:
                 description: Image used for the ovsdb-server and ovs-vswitchd containers
@@ -161,8 +168,15 @@ spec:
                 type: string
               ovsLogLevel:
                 default: info
-                description: OVSLogLevel - Set log level off, emer, err, warn, info,
+                description: OVSLogLevel - Set log level off, emer, err, warn, info
                   or dbg. Default is info.
+                enum:
+                - "off"
+                - emer
+                - err
+                - warn
+                - info
+                - dbg
                 type: string
               resources:
                 description: |-

--- a/api/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/api/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -78,7 +78,15 @@ spec:
                 type: integer
               logLevel:
                 default: info
-                description: LogLevel - Set log level info, dbg, emer etc
+                description: LogLevel - Set log level off, emer, err, warn, info or
+                  dbg. Default is info.
+                enum:
+                - "off"
+                - emer
+                - err
+                - warn
+                - info
+                - dbg
                 type: string
               metricsEnabled:
                 default: true

--- a/api/bases/ovn.openstack.org_ovnnorthds.yaml
+++ b/api/bases/ovn.openstack.org_ovnnorthds.yaml
@@ -58,7 +58,15 @@ spec:
                 type: string
               logLevel:
                 default: info
-                description: LogLevel - Set log level info, dbg, emer etc
+                description: LogLevel - Set log level off, emer, err, warn, info or
+                  dbg. Default is info.
+                enum:
+                - "off"
+                - emer
+                - err
+                - warn
+                - info
+                - dbg
                 type: string
               metricsEnabled:
                 default: true

--- a/api/v1beta1/ovncontroller_types.go
+++ b/api/v1beta1/ovncontroller_types.go
@@ -95,13 +95,15 @@ type OVNControllerSpecCore struct {
 	NetworkAttachment string `json:"networkAttachment"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=off;emer;err;warn;info;dbg
 	// +kubebuilder:default=info
-	// OVNLogLevel - Set log level off, emer, err, warn, info, or dbg. Default is info.
+	// OVNLogLevel - Set log level off, emer, err, warn, info or dbg. Default is info.
 	OVNLogLevel string `json:"ovnLogLevel,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=off;emer;err;warn;info;dbg
 	// +kubebuilder:default=info
-	// OVSLogLevel - Set log level off, emer, err, warn, info, or dbg. Default is info.
+	// OVSLogLevel - Set log level off, emer, err, warn, info or dbg. Default is info.
 	OVSLogLevel string `json:"ovsLogLevel,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/ovndbcluster_types.go
+++ b/api/v1beta1/ovndbcluster_types.go
@@ -84,8 +84,9 @@ type OVNDBClusterSpecCore struct {
 	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+    // +kubebuilder:validation:Enum=off;emer;err;warn;info;dbg
 	// +kubebuilder:default=info
-	// LogLevel - Set log level info, dbg, emer etc
+	// LogLevel - Set log level off, emer, err, warn, info or dbg. Default is info.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/ovnnorthd_types.go
+++ b/api/v1beta1/ovnnorthd_types.go
@@ -67,8 +67,9 @@ type OVNNorthdSpecCore struct {
 	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+    // +kubebuilder:validation:Enum=off;emer;err;warn;info;dbg
 	// +kubebuilder:default=info
-	// LogLevel - Set log level info, dbg, emer etc
+	// LogLevel - Set log level off, emer, err, warn, info or dbg. Default is info.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/ovn.openstack.org_ovncontrollers.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovncontrollers.yaml
@@ -152,8 +152,15 @@ spec:
                 type: string
               ovnLogLevel:
                 default: info
-                description: OVNLogLevel - Set log level off, emer, err, warn, info,
+                description: OVNLogLevel - Set log level off, emer, err, warn, info
                   or dbg. Default is info.
+                enum:
+                - "off"
+                - emer
+                - err
+                - warn
+                - info
+                - dbg
                 type: string
               ovsContainerImage:
                 description: Image used for the ovsdb-server and ovs-vswitchd containers
@@ -161,8 +168,15 @@ spec:
                 type: string
               ovsLogLevel:
                 default: info
-                description: OVSLogLevel - Set log level off, emer, err, warn, info,
+                description: OVSLogLevel - Set log level off, emer, err, warn, info
                   or dbg. Default is info.
+                enum:
+                - "off"
+                - emer
+                - err
+                - warn
+                - info
+                - dbg
                 type: string
               resources:
                 description: |-

--- a/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovndbclusters.yaml
@@ -78,7 +78,15 @@ spec:
                 type: integer
               logLevel:
                 default: info
-                description: LogLevel - Set log level info, dbg, emer etc
+                description: LogLevel - Set log level off, emer, err, warn, info or
+                  dbg. Default is info.
+                enum:
+                - "off"
+                - emer
+                - err
+                - warn
+                - info
+                - dbg
                 type: string
               metricsEnabled:
                 default: true

--- a/config/crd/bases/ovn.openstack.org_ovnnorthds.yaml
+++ b/config/crd/bases/ovn.openstack.org_ovnnorthds.yaml
@@ -58,7 +58,15 @@ spec:
                 type: string
               logLevel:
                 default: info
-                description: LogLevel - Set log level info, dbg, emer etc
+                description: LogLevel - Set log level off, emer, err, warn, info or
+                  dbg. Default is info.
+                enum:
+                - "off"
+                - emer
+                - err
+                - warn
+                - info
+                - dbg
                 type: string
               metricsEnabled:
                 default: true


### PR DESCRIPTION
Currently log level can be set to any string value, problem is that it only accepts a set of strings (which are only on the description) but user can set this values to whatever he wants, and could make the operator not being able to spawn all needed pods.

Allowing only to add the correct values

Resolves: [OSPRH-28896](https://redhat.atlassian.net/browse/OSPRH-28896)