### PR TITLE
Fix OVN encap IP detection

### DIFF
--- a/templates/ovncontroller/bin/start-vswitchd.sh
+++ b/templates/ovncontroller/bin/start-vswitchd.sh
@@ -21,8 +21,15 @@ wait_for_ovsdb_server
 # wait_for_ovsdb_server interrim check would make the script exit.
 set -ex
 
-# Configure encap IP.
-OVNEncapIP=$(ip -o addr show dev {{ .OVNEncapNIC }} scope global | awk '{print $4}' | cut -d/ -f1)
+# Configure encap IP - prefer IPv4, fallback to IPv6 if needed, take first address only.
+OVNEncapIP=$(ip -o -4 addr show dev {{ .OVNEncapNIC }} scope global | awk '{print $4}' | cut -d/ -f1 | head -n1)
+if [ -z "$OVNEncapIP" ]; then
+    OVNEncapIP=$(ip -o -6 addr show dev {{ .OVNEncapNIC }} scope global | awk '{print $4}' | cut -d/ -f1 | head -n1)
+fi
+if [ -z "$OVNEncapIP" ]; then
+    echo "ERROR: Could not find any global IP address on interface {{ .OVNEncapNIC }}"
+    exit 1
+fi
 ovs-vsctl --no-wait set open . external-ids:ovn-encap-ip=${OVNEncapIP}
 
 # Before starting vswitchd, block it from flushing existing datapath flows.


### PR DESCRIPTION
With the current detection logic based on how
cluster is setup we can have multiple IPs detected while we expect single IP for this setting.
OVN itself support multiple IPs comma seperated and setup multiple tunnels for those and also require
to set default encap IP along.

But in our case we only require single IP. So to
fix this we now do as follows:-
- check for IPv4 address
- if IPv4 absent we fallback to IPv6
- if both are absent we exit
- If more than one IP exist for a type we choose first