### PR TITLE
Copy LSP.tag to LSP.tag_request if it is unset

### DIFF
--- a/internal/ovnnorthd/statefulset.go
+++ b/internal/ovnnorthd/statefulset.go
@@ -31,7 +31,11 @@ import (
 
 const (
 	// ServiceCommand -
-	ServiceCommand = "/usr/bin/ovn-northd"
+	// TODO(otherwiseguy) Revert to /usr/bin/ovn-northd and remove setup.sh script
+	// once we are sure tag to tag_request migration no longer needed for a release
+	// i.e migration is already done in old running release and is the minimum required
+	// to move to the next release
+	ServiceCommand = "/usr/local/bin/container-scripts/setup.sh"
 )
 
 // StatefulSet func

--- a/templates/ovnnorthd/bin/setup.sh
+++ b/templates/ovnnorthd/bin/setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+for arg in "$@"; do
+    case $arg in
+        --ovnnb-db=*) NB_DB="${arg#*=}" ;;
+        --certificate=*) CERT="${arg#*=}" ;;
+        --private-key=*) PKEY="${arg#*=}" ;;
+        --ca-cert=*) CACERT="${arg#*=}" ;;
+    esac
+done
+
+if [ -n "$NB_DB" ]; then
+    NBCTL="ovn-nbctl --no-leader-only"
+    if [ -n "$CERT" ]; then
+        NBCTL="$NBCTL --certificate=$CERT --private-key=$PKEY --ca-cert=$CACERT"
+    fi
+
+    # NOTE(twilson) This will wait for the ovsdb connection before detaching
+    export OVN_NB_DAEMON=$(${NBCTL} --pidfile --detach --db=$NB_DB)
+
+    # NOTE(twilson) ovn-nbctl will be connecting to the daemon successfully, so will wait forever
+    # until the daemon responds. So even if there is a disconnect after initially connecting it waits.
+    #
+    # Due to OVN commit `171ed24dd northd: Clear stale LSP tags on tag_request removal.` and neutron's
+    # historical practice of setting the tag directly instead of using tag_request, 26.03.1+ versions
+    # of northd will clear all tags set by neutron prior to 18.0 FR6. For upgrades to FR6 and beyond
+    # from an affected prior version (<= 18.0 FR6) this will fix the issue before northd starts.
+    #
+    # This is safe to remove when the minimum version from which upgrades are allowed is 18.0 FR7 or
+    # later. Note that this setup script itself only exists to run this fix.
+    for port in $(${NBCTL} --bare --columns _uuid find logical_switch_port tag!='[]' tag_request='[]'); do
+        tag=$(${NBCTL} lsp-get-tag $port)
+        echo "Fixing tag_request for $port tag=$tag"
+        ${NBCTL} set logical_switch_port $port tag_request=$tag
+    done
+
+    kill $(cat $OVN_RUNDIR/ovn-nbctl.pid)
+    unset OVN_NB_DAEMON
+fi
+
+exec /usr/bin/ovn-northd "$@"

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -138,7 +138,7 @@ spec:
             weight: 100
       containers:
       - command:
-        - /usr/bin/ovn-northd
+        - /usr/local/bin/container-scripts/setup.sh
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:


### PR DESCRIPTION
OVN 26.03.1 contains a fix that clears tags when the tag_request is cleared. For years, neutron has set the tag directly without setting a request. This if fixed in the neutron code, but on upgrade, it is possible that ports with tags and no tag_request will have the tags cleared before neutron could restart to fix them. Due to upgrade races between ovndbcluster and northd, this hacks the fix into northd startup.

Resolves: [OSPRH-31613](https://redhat.atlassian.net/browse/OSPRH-31613)