### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/ovncontroller_webhook.go
+++ b/api/v1beta1/ovncontroller_webhook.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -43,8 +42,6 @@ func SetupOVNControllerDefaults(defaults OVNControllerDefaults) {
 	ovnDefaults = defaults
 	ovncontrollerlog.Info("OVNController defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &OVNController{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *OVNController) Default() {
@@ -71,8 +68,6 @@ func (spec *OVNControllerSpec) Default() {
 func (spec *OVNControllerSpecCore) Default() {
 	// nothing here yet
 }
-
-var _ webhook.Validator = &OVNController{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *OVNController) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/ovndbcluster_webhook.go
+++ b/api/v1beta1/ovndbcluster_webhook.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -49,8 +48,6 @@ func SetupOVNDBClusterDefaults(defaults OVNDBClusterDefaults) {
 	ovnDbClusterDefaults = defaults
 	ovndbclusterlog.Info("OVNDBCluster defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &OVNDBCluster{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *OVNDBCluster) Default() {
@@ -78,8 +75,6 @@ func (spec *OVNDBClusterSpec) Default() {
 func (spec *OVNDBClusterSpecCore) Default() {
 	// nothing here yet
 }
-
-var _ webhook.Validator = &OVNDBCluster{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *OVNDBCluster) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/ovnnorthd_webhook.go
+++ b/api/v1beta1/ovnnorthd_webhook.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -48,8 +47,6 @@ func SetupOVNNorthdDefaults(defaults OVNNorthdDefaults) {
 	ovnNorthdDefaults = defaults
 	ovndbclusterlog.Info("OVNNorthd defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &OVNNorthd{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *OVNNorthd) Default() {
@@ -73,8 +70,6 @@ func (spec *OVNNorthdSpec) Default() {
 func (spec *OVNNorthdSpecCore) Default() {
 	// nothing here yet
 }
-
-var _ webhook.Validator = &OVNNorthd{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *OVNNorthd) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)