### PR TITLE
Add PodDisruptionBudget for OVNDBCluster NB and SB

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -144,6 +144,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/internal/controller/ovndbcluster_controller.go
+++ b/internal/controller/ovndbcluster_controller.go
@@ -49,6 +49,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/job"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pdb"
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/statefulset"
@@ -59,8 +60,10 @@ import (
 	"github.com/openstack-k8s-operators/ovn-operator/internal/ovndbcluster"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // OVNDBClusterReconciler reconciles a OVNDBCluster object
@@ -108,6 +111,7 @@ func (r *OVNDBClusterReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=restricted-v2,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile - OVN DBCluster
@@ -161,6 +165,7 @@ func (r *OVNDBClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),
 		condition.UnknownCondition(condition.RoleBindingReadyCondition, condition.InitReason, condition.RoleBindingReadyInitMessage),
 		condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+		condition.UnknownCondition(condition.PDBReadyCondition, condition.InitReason, condition.PDBReadyInitMessage),
 		condition.UnknownCondition(ovnv1.ExternalConfigReadyCondition, condition.InitReason, ovnv1.ExternalConfigInitMessage),
 	)
 
@@ -280,6 +285,7 @@ func (r *OVNDBClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&infranetworkv1.DNSData{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(&ovnv1.OVNController{}, handler.EnqueueRequestsFromMapFunc(ovnv1.OVNCRNamespaceMapFunc(crs, mgr.GetClient()))).
 		Watches(
 			&corev1.Secret{},
@@ -652,6 +658,37 @@ func (r *OVNDBClusterReconciler) reconcileNormal(ctx context.Context, instance *
 			condition.DeploymentReadyRunningMessage))
 		return ctrlResult, nil
 	}
+
+	//
+	// PodDisruptionBudget
+	//
+	if instance.Spec.Replicas != nil && *instance.Spec.Replicas > 1 {
+		pdbSpec := pdb.MaxUnavailablePodDisruptionBudget(
+			serviceName,
+			instance.Namespace,
+			intstr.FromInt(1),
+			serviceLabels,
+		)
+		pdbInstance := pdb.NewPDB(pdbSpec, 5*time.Second)
+
+		ctrlResult, err := pdbInstance.CreateOrPatch(ctx, helper)
+		if err != nil {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.PDBReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.PDBReadyErrorMessage, err.Error()))
+			return ctrl.Result{}, err
+		} else if (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, nil
+		}
+	} else {
+		err := pdb.DeletePDBWithName(ctx, helper, serviceName, instance.Namespace)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete PDB: %w", err)
+		}
+	}
+	instance.Status.Conditions.MarkTrue(condition.PDBReadyCondition, condition.PDBReadyMessage)
 
 	// create Statefulset - end
 	// Handle service init

--- a/test/functional/ovndbcluster_controller_test.go
+++ b/test/functional/ovndbcluster_controller_test.go
@@ -34,6 +34,8 @@ import (
 	ovn_common "github.com/openstack-k8s-operators/ovn-operator/internal/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -1463,6 +1465,121 @@ var _ = Describe("OVNDBCluster controller", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 
+	})
+
+	When("A OVNDBCluster instance is created with replicas > 1", func() {
+		var OVNDBClusterName types.NamespacedName
+		var statefulSetName types.NamespacedName
+
+		BeforeEach(func() {
+			spec := GetDefaultOVNDBClusterSpec()
+			replicas := int32(3)
+			spec.Replicas = &replicas
+			instance := CreateOVNDBCluster(namespace, spec)
+			OVNDBClusterName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+			DeferCleanup(th.DeleteInstance, instance)
+
+			statefulSetName = types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovsdbserver-nb",
+			}
+			th.SimulateStatefulSetReplicaReady(statefulSetName)
+		})
+
+		It("should create a PodDisruptionBudget", func() {
+			pdbName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovsdbserver-nb",
+			}
+			Eventually(func(g Gomega) {
+				pdb := th.GetPodDisruptionBudget(pdbName)
+				g.Expect(pdb.Spec.MaxUnavailable.IntValue()).To(Equal(1))
+				g.Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue("service", "ovsdbserver-nb"))
+			}, timeout, interval).Should(Succeed())
+
+			th.ExpectCondition(
+				OVNDBClusterName,
+				ConditionGetterFunc(OVNDBClusterConditionGetter),
+				condition.PDBReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
+
+		It("should delete the PDB when scaled down to 1", func() {
+			pdbName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovsdbserver-nb",
+			}
+			th.AssertPodDisruptionBudgetExists(pdbName)
+
+			ScaleDBCluster(OVNDBClusterName, 1)
+
+			Eventually(func(g Gomega) {
+				pdb := &policyv1.PodDisruptionBudget{}
+				err := k8sClient.Get(ctx, pdbName, pdb)
+				g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			th.ExpectCondition(
+				OVNDBClusterName,
+				ConditionGetterFunc(OVNDBClusterConditionGetter),
+				condition.PDBReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
+	})
+
+	When("A OVNDBCluster instance is created with 1 replica", func() {
+		var OVNDBClusterName types.NamespacedName
+
+		BeforeEach(func() {
+			instance := CreateOVNDBCluster(namespace, GetDefaultOVNDBClusterSpec())
+			OVNDBClusterName = types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+			DeferCleanup(th.DeleteInstance, instance)
+
+			statefulSetName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovsdbserver-nb",
+			}
+			th.SimulateStatefulSetReplicaReady(statefulSetName)
+		})
+
+		It("should not create a PodDisruptionBudget", func() {
+			pdbName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovsdbserver-nb",
+			}
+			th.AssertPodDisruptionBudgetDoesNotExist(pdbName)
+
+			th.ExpectCondition(
+				OVNDBClusterName,
+				ConditionGetterFunc(OVNDBClusterConditionGetter),
+				condition.PDBReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
+
+		It("should create a PDB when scaled up to 3", func() {
+			pdbName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovsdbserver-nb",
+			}
+			th.AssertPodDisruptionBudgetDoesNotExist(pdbName)
+
+			ScaleDBCluster(OVNDBClusterName, 3)
+
+			Eventually(func(g Gomega) {
+				pdb := th.GetPodDisruptionBudget(pdbName)
+				g.Expect(pdb.Spec.MaxUnavailable.IntValue()).To(Equal(1))
+			}, timeout, interval).Should(Succeed())
+
+			th.ExpectCondition(
+				OVNDBClusterName,
+				ConditionGetterFunc(OVNDBClusterConditionGetter),
+				condition.PDBReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
 	})
 
 	When("OVNDB is created with topologyref", func() {


### PR DESCRIPTION
When an OVNDBCluster has more than one replica, create a PodDisruptionBudget with maxUnavailable=1 to prevent voluntary disruptions from taking down too many OVSDB RAFT members simultaneously. The PDB is automatically deleted when the cluster is scaled back to a single replica.