### PR TITLE
Harden privileged OVN controller pod security contexts

### DIFF
--- a/internal/ovncontroller/configjob.go
+++ b/internal/ovncontroller/configjob.go
@@ -36,8 +36,6 @@ func ConfigJob(
 ) ([]*batchv1.Job, error) {
 
 	var jobs []*batchv1.Job
-	runAsUser := int64(0)
-	privileged := true
 	// NOTE(slaweq): set TTLSecondsAfterFinished=0 will clean done
 	// configuration job automatically right after it will be finished
 	jobTTLAfterFinished := int32(0)
@@ -86,6 +84,7 @@ func ConfigJob(
 					TTLSecondsAfterFinished: &jobTTLAfterFinished,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
+							SecurityContext:    getPrivilegedDaemonSetPodSecurityContext(),
 							RestartPolicy:      corev1.RestartPolicyOnFailure,
 							ServiceAccountName: instance.RbacResourceName(),
 							Containers: []corev1.Container{
@@ -95,14 +94,11 @@ func ConfigJob(
 									Command: []string{
 										"/bin/bash", "-c", strings.Join(commands, " "),
 									},
-									Args: []string{},
-									SecurityContext: &corev1.SecurityContext{
-										RunAsUser:  &runAsUser,
-										Privileged: &privileged,
-									},
-									Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-									VolumeMounts: GetOVNControllerVolumeMounts(true),
-									Resources:    instance.Spec.Resources,
+									Args:            []string{},
+									SecurityContext: getPrivilegedHostPathSecurityContext(nil),
+									Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+									VolumeMounts:    GetOVNControllerVolumeMounts(true),
+									Resources:       instance.Spec.Resources,
 								},
 							},
 							Volumes:  GetOVNControllerVolumes(instance.Name, instance.Namespace, true),

--- a/internal/ovncontroller/daemonset.go
+++ b/internal/ovncontroller/daemonset.go
@@ -92,9 +92,6 @@ func CreateOVNDaemonSet(
 		},
 	}
 
-	runAsUser := int64(0)
-	privileged := true
-
 	envVars := map[string]env.Setter{}
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 
@@ -109,19 +106,12 @@ func CreateOVNDaemonSet(
 					},
 				},
 			},
-			Image: instance.Spec.OvnContainerImage,
-			SecurityContext: &corev1.SecurityContext{
-				Capabilities: &corev1.Capabilities{
-					Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"},
-					Drop: []corev1.Capability{},
-				},
-				RunAsUser:  &runAsUser,
-				Privileged: &privileged,
-			},
-			Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
-			VolumeMounts:   mounts,
-			ReadinessProbe: ovnControllerReadinessProbe,
-			LivenessProbe:  ovnControllerLivenessProbe,
+			Image:           instance.Spec.OvnContainerImage,
+			SecurityContext: getPrivilegedHostPathSecurityContext(privilegedOVSCapabilities),
+			Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+			VolumeMounts:    mounts,
+			ReadinessProbe:  ovnControllerReadinessProbe,
+			LivenessProbe:   ovnControllerLivenessProbe,
 			// TODO: consider the fact that resources are now double booked
 			Resources:                instance.Spec.Resources,
 			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
@@ -142,6 +132,7 @@ func CreateOVNDaemonSet(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext:    getPrivilegedDaemonSetPodSecurityContext(),
 					ServiceAccountName: instance.RbacResourceName(),
 					Containers:         containers,
 					Volumes:            volumes,
@@ -233,27 +224,17 @@ func CreateOVSDaemonSet(
 		},
 	}
 
-	runAsUser := int64(0)
-	privileged := true
-
 	envVars := map[string]env.Setter{}
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 
 	initContainers := []corev1.Container{
 		{
-			Name:    "ovsdb-server-init",
-			Command: []string{"/usr/local/bin/container-scripts/init-ovsdb-server.sh"},
-			Image:   instance.Spec.OvsContainerImage,
-			SecurityContext: &corev1.SecurityContext{
-				Capabilities: &corev1.Capabilities{
-					Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"},
-					Drop: []corev1.Capability{},
-				},
-				RunAsUser:  &runAsUser,
-				Privileged: &privileged,
-			},
-			Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-			VolumeMounts: GetOVSDbVolumeMounts(),
+			Name:            "ovsdb-server-init",
+			Command:         []string{"/usr/local/bin/container-scripts/init-ovsdb-server.sh"},
+			Image:           instance.Spec.OvsContainerImage,
+			SecurityContext: getPrivilegedHostPathSecurityContext(privilegedOVSCapabilities),
+			Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+			VolumeMounts:    GetOVSDbVolumeMounts(),
 		},
 	}
 
@@ -269,17 +250,10 @@ func CreateOVSDaemonSet(
 					},
 				},
 			},
-			Image: instance.Spec.OvsContainerImage,
-			SecurityContext: &corev1.SecurityContext{
-				Capabilities: &corev1.Capabilities{
-					Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"},
-					Drop: []corev1.Capability{},
-				},
-				RunAsUser:  &runAsUser,
-				Privileged: &privileged,
-			},
-			Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-			VolumeMounts: GetOVSDbVolumeMounts(),
+			Image:           instance.Spec.OvsContainerImage,
+			SecurityContext: getPrivilegedHostPathSecurityContext(privilegedOVSCapabilities),
+			Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+			VolumeMounts:    GetOVSDbVolumeMounts(),
 			// TODO: consider the fact that resources are now double booked
 			Resources:                instance.Spec.Resources,
 			LivenessProbe:            ovsDbLivenessProbe,
@@ -296,17 +270,10 @@ func CreateOVSDaemonSet(
 					},
 				},
 			},
-			Image: instance.Spec.OvsContainerImage,
-			SecurityContext: &corev1.SecurityContext{
-				Capabilities: &corev1.Capabilities{
-					Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"},
-					Drop: []corev1.Capability{},
-				},
-				RunAsUser:  &runAsUser,
-				Privileged: &privileged,
-			},
-			Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-			VolumeMounts: GetVswitchdVolumeMounts(),
+			Image:           instance.Spec.OvsContainerImage,
+			SecurityContext: getPrivilegedHostPathSecurityContext(privilegedOVSCapabilities),
+			Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+			VolumeMounts:    GetVswitchdVolumeMounts(),
 			// TODO: consider the fact that resources are now double booked
 			Resources:                instance.Spec.Resources,
 			LivenessProbe:            ovsVswitchdLivenessProbe,
@@ -329,6 +296,7 @@ func CreateOVSDaemonSet(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext:    getPrivilegedDaemonSetPodSecurityContext(),
 					ServiceAccountName: instance.RbacResourceName(),
 					InitContainers:     initContainers,
 					Containers:         containers,
@@ -445,22 +413,12 @@ func CreateMetricsDaemonSet(
 	envVars := map[string]env.Setter{}
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 
-	runAsUser := int64(0)
-	privileged := true
-
 	containers := []corev1.Container{
 		{
-			Name:    "openstack-network-exporter",
-			Image:   instance.Spec.ExporterImage,
-			Command: []string{"/app/openstack-network-exporter"},
-			SecurityContext: &corev1.SecurityContext{
-				Capabilities: &corev1.Capabilities{
-					Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"},
-					Drop: []corev1.Capability{},
-				},
-				RunAsUser:  &runAsUser,
-				Privileged: &privileged,
-			},
+			Name:            "openstack-network-exporter",
+			Image:           instance.Spec.ExporterImage,
+			Command:         []string{"/app/openstack-network-exporter"},
+			SecurityContext: getPrivilegedHostPathSecurityContext(privilegedOVSCapabilities),
 			Env: env.MergeEnvs([]corev1.EnvVar{
 				{
 					Name:  "OPENSTACK_NETWORK_EXPORTER_YAML",
@@ -486,6 +444,7 @@ func CreateMetricsDaemonSet(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext:    getPrivilegedDaemonSetPodSecurityContext(),
 					ServiceAccountName: instance.RbacResourceName(),
 					Containers:         containers,
 					Volumes:            volumes,

--- a/internal/ovncontroller/securitycontext.go
+++ b/internal/ovncontroller/securitycontext.go
@@ -1,0 +1,41 @@
+package ovncontroller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+var privilegedOVSCapabilities = []corev1.Capability{
+	"NET_ADMIN",
+	"SYS_ADMIN",
+	"SYS_NICE",
+}
+
+func getPrivilegedDaemonSetPodSecurityContext() *corev1.PodSecurityContext {
+	return &corev1.PodSecurityContext{
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+func getPrivilegedHostPathSecurityContext(capabilities []corev1.Capability) *corev1.SecurityContext {
+	securityContext := &corev1.SecurityContext{
+		RunAsUser:                ptr.To(int64(0)),
+		Privileged:               ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(true),
+		ReadOnlyRootFilesystem:   ptr.To(false),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
+	if len(capabilities) > 0 {
+		securityContext.Capabilities = &corev1.Capabilities{
+			Add:  capabilities,
+			Drop: []corev1.Capability{},
+		}
+	}
+
+	return securityContext
+}

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -386,6 +386,40 @@ func GetServicesListWithLabel(namespace string, labelSelectorMap ...map[string]s
 	return serviceList
 }
 
+func expectPrivilegedDaemonSetPodSecurityContext(podSecurityContext *corev1.PodSecurityContext) {
+	Expect(podSecurityContext).NotTo(BeNil())
+	Expect(podSecurityContext.SeccompProfile).NotTo(BeNil())
+	Expect(podSecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectPrivilegedHostPathSecurityContext(
+	securityContext *corev1.SecurityContext,
+	withOVSCapabilities bool,
+) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeTrue())
+	Expect(securityContext.ReadOnlyRootFilesystem).NotTo(BeNil())
+	Expect(*securityContext.ReadOnlyRootFilesystem).To(BeFalse())
+	Expect(securityContext.Privileged).NotTo(BeNil())
+	Expect(*securityContext.Privileged).To(BeTrue())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(int64(0)))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+
+	if withOVSCapabilities {
+		Expect(securityContext.Capabilities).NotTo(BeNil())
+		Expect(securityContext.Capabilities.Add).To(ContainElements(
+			corev1.Capability("NET_ADMIN"),
+			corev1.Capability("SYS_ADMIN"),
+			corev1.Capability("SYS_NICE"),
+		))
+	} else {
+		Expect(securityContext.Capabilities).To(BeNil())
+	}
+}
+
 // Topology functions
 
 // GetSampleDaemonSetTopologySpec - A sample (and opinionated) Topology Spec used to

--- a/test/functional/ovncontroller_controller_test.go
+++ b/test/functional/ovncontroller_controller_test.go
@@ -160,6 +160,36 @@ var _ = Describe("OVNController controller", func() {
 			Expect(ds.Spec.Template.Spec.Containers[1].ReadinessProbe).ShouldNot(BeNil())
 		})
 
+		It("should configure hardened privileged security contexts on DaemonSets", func() {
+			ds := GetDaemonSet(types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller",
+			})
+			expectPrivilegedDaemonSetPodSecurityContext(ds.Spec.Template.Spec.SecurityContext)
+			expectPrivilegedHostPathSecurityContext(
+				ds.Spec.Template.Spec.Containers[0].SecurityContext,
+				true,
+			)
+
+			ds = GetDaemonSet(types.NamespacedName{
+				Namespace: namespace,
+				Name:      "ovn-controller-ovs",
+			})
+			expectPrivilegedDaemonSetPodSecurityContext(ds.Spec.Template.Spec.SecurityContext)
+			expectPrivilegedHostPathSecurityContext(
+				ds.Spec.Template.Spec.InitContainers[0].SecurityContext,
+				true,
+			)
+			expectPrivilegedHostPathSecurityContext(
+				ds.Spec.Template.Spec.Containers[0].SecurityContext,
+				true,
+			)
+			expectPrivilegedHostPathSecurityContext(
+				ds.Spec.Template.Spec.Containers[1].SecurityContext,
+				true,
+			)
+		})
+
 		When("OVNDBCluster instances are available without networkAttachments", func() {
 			var scriptsCM types.NamespacedName
 			var dbs []types.NamespacedName
@@ -268,6 +298,13 @@ var _ = Describe("OVNController controller", func() {
 				Eventually(func() batchv1.Job {
 					return *th.GetJob(configJob)
 				}, timeout, interval).ShouldNot(BeNil())
+
+				job := th.GetJob(configJob)
+				expectPrivilegedDaemonSetPodSecurityContext(job.Spec.Template.Spec.SecurityContext)
+				expectPrivilegedHostPathSecurityContext(
+					job.Spec.Template.Spec.Containers[0].SecurityContext,
+					false,
+				)
 			})
 
 			It("should not create a config job", func() {
@@ -1477,6 +1514,11 @@ var _ = Describe("OVNController controller", func() {
 			Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(ds.Spec.Template.Spec.Containers[0].Name).To(Equal("openstack-network-exporter"))
 			Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("quay.io/openstack-k8s-operators/openstack-network-exporter:current-podified"))
+			expectPrivilegedDaemonSetPodSecurityContext(ds.Spec.Template.Spec.SecurityContext)
+			expectPrivilegedHostPathSecurityContext(
+				ds.Spec.Template.Spec.Containers[0].SecurityContext,
+				true,
+			)
 		})
 
 		It("should create a metrics Service", func() {

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -17,6 +17,7 @@
 # - ovsdbserver-sb-0 Service
 # - OVNController Daemonset created as many pods as nodes*2
 # - OVNControllerOVS Daemonset created as many pods as nodes*2
+# - Privileged DaemonSet/Pod security contexts (seccomp, readOnlyRootFilesystem)
 # - 1 PVC for OVNDBCluster NB
 # - 1 PVC for OVNDBCluster SB
 
@@ -181,6 +182,26 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ovn-controller
+spec:
+  template:
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: ovn-controller
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - SYS_NICE
+          privileged: true
+          readOnlyRootFilesystem: false
+          runAsUser: 0
+          seccompProfile:
+            type: RuntimeDefault
 status:
   numberMisscheduled: 0
 ---
@@ -188,6 +209,53 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ovn-controller-ovs
+spec:
+  template:
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+      - name: ovsdb-server-init
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - SYS_NICE
+          privileged: true
+          readOnlyRootFilesystem: false
+          runAsUser: 0
+          seccompProfile:
+            type: RuntimeDefault
+      containers:
+      - name: ovsdb-server
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - SYS_NICE
+          privileged: true
+          readOnlyRootFilesystem: false
+          runAsUser: 0
+          seccompProfile:
+            type: RuntimeDefault
+      - name: ovs-vswitchd
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - SYS_NICE
+          privileged: true
+          readOnlyRootFilesystem: false
+          runAsUser: 0
+          seccompProfile:
+            type: RuntimeDefault
 status:
   numberMisscheduled: 0
 ---
@@ -226,6 +294,24 @@ metadata:
   labels:
     service: ovn-controller
   generateName: ovn-controller-
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: ovn-controller
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        add:
+        - NET_ADMIN
+        - SYS_ADMIN
+        - SYS_NICE
+      privileged: true
+      readOnlyRootFilesystem: false
+      runAsUser: 0
+      seccompProfile:
+        type: RuntimeDefault
 status:
   phase: Running
   containerStatuses:
@@ -240,6 +326,51 @@ metadata:
   labels:
     service: ovn-controller-ovs
   generateName: ovn-controller-ovs-
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  initContainers:
+  - name: ovsdb-server-init
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        add:
+        - NET_ADMIN
+        - SYS_ADMIN
+        - SYS_NICE
+      privileged: true
+      readOnlyRootFilesystem: false
+      runAsUser: 0
+      seccompProfile:
+        type: RuntimeDefault
+  containers:
+  - name: ovsdb-server
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        add:
+        - NET_ADMIN
+        - SYS_ADMIN
+        - SYS_NICE
+      privileged: true
+      readOnlyRootFilesystem: false
+      runAsUser: 0
+      seccompProfile:
+        type: RuntimeDefault
+  - name: ovs-vswitchd
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        add:
+        - NET_ADMIN
+        - SYS_ADMIN
+        - SYS_NICE
+      privileged: true
+      readOnlyRootFilesystem: false
+      runAsUser: 0
+      seccompProfile:
+        type: RuntimeDefault
 status:
   phase: Running
   containerStatuses:

--- a/test/kuttl/tests/ovn_metrics/02-assert.yaml
+++ b/test/kuttl/tests/ovn_metrics/02-assert.yaml
@@ -2,7 +2,33 @@
 # Check for:
 #
 # - Exported metrics
+# - Metrics DaemonSet security context
 
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ovn-controller-metrics
+spec:
+  template:
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: openstack-network-exporter
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - SYS_NICE
+          privileged: true
+          readOnlyRootFilesystem: false
+          runAsUser: 0
+          seccompProfile:
+            type: RuntimeDefault
+---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 60


### PR DESCRIPTION
Set RuntimeDefault seccomp and explicit readOnlyRootFilesystem on privileged DaemonSet, metrics, and config job workloads. Add functional and KUTTL assertions for the new settings.

Assited-By: Cursor Composer 2.5

Closes: [OSPRH-34172](https://redhat.atlassian.net/browse/OSPRH-34172)